### PR TITLE
Updated MAINTAINERS.md format.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,5 +1,9 @@
-## Maintainers
+## Overview
 
-| Maintainer       | GitHub ID                                           | Affiliation |
-| ---------------- | --------------------------------------------------- | ----------- |
-| Rishabh Singh    | [rishabh6788](https://github.com/rishabh6788)       | Amazon      |
+This document contains a list of maintainers in this repo. See [opensearch-project/.github/RESPONSIBILITIES.md](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#maintainer-responsibilities) that explains what the role of maintainer means, what maintainers do in this and other repos, and how they should be doing it. If you're interested in contributing, and becoming a maintainer, see [CONTRIBUTING](CONTRIBUTING.md).
+
+## Current Maintainers
+
+| Maintainer    | GitHub ID                                     | Affiliation |
+| ------------- | --------------------------------------------- | ----------- |
+| Rishabh Singh | [rishabh6788](https://github.com/rishabh6788) | Amazon      |


### PR DESCRIPTION
Coming from https://github.com/opensearch-project/.github/issues/121, updated MAINTAINERS.md to match opensearch-project recommended format.