### PR TITLE
Fix parsing of jvmSysProps

### DIFF
--- a/lib/infra/infra-stack.ts
+++ b/lib/infra/infra-stack.ts
@@ -434,7 +434,7 @@ export class InfraStack extends Stack {
     if (props.jvmSysPropsString.toString() !== 'undefined') {
       // @ts-ignore
       cfnInitConfig.push(InitCommand.shellCommand(`set -ex; cd opensearch; jvmSysPropsList=$(echo "${props.jvmSysPropsString.toString()}" | tr ',' '\\n');`
-      + 'for sysProp in $jvmSysPropsList;do;echo "-D$sysProp" >> config/jvm.options;done',
+      + 'for sysProp in $jvmSysPropsList;do echo "-D$sysProp" >> config/jvm.options;done',
       {
         cwd: '/home/ec2-user',
         ignoreErrors: false,


### PR DESCRIPTION
Signed-off-by: Suraj Singh <surajrider@gmail.com>

### Description
This change fixes the parsing logic for jvmSysProps by removing the unnecessary `;` post `do` in bash for lop. 

### Issues Resolved
NA

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
