### PR TITLE
Add metrics in CloudWatch agent configuration file

### DIFF
--- a/lib/cloudwatch/cloudwatch-agent.ts
+++ b/lib/cloudwatch/cloudwatch-agent.ts
@@ -8,9 +8,11 @@ compatible open source license. */
 import { InitFile, InitFileOptions } from 'aws-cdk-lib/aws-ec2';
 import { CloudwatchAgentSection } from './agent-section';
 import { CloudwatchLogsSection } from './logs-section';
+import { CloudwatchMetricsSection } from "./metrics-section";
 
 export interface CloudwatchAgentConfig {
     agent: CloudwatchAgentSection,
+    metrics: CloudwatchMetricsSection
     logs: CloudwatchLogsSection
 }
 

--- a/lib/cloudwatch/metrics-section.ts
+++ b/lib/cloudwatch/metrics-section.ts
@@ -1,0 +1,44 @@
+/* Copyright OpenSearch Contributors
+SPDX-License-Identifier: Apache-2.0
+
+The OpenSearch Contributors require contributions made to
+this file be licensed under the Apache-2.0 license or a
+compatible open source license. */
+
+interface MetricDefinition {
+    measurement: string[];
+}
+
+interface EditableCloudwatchMetricsSection {
+    // eslint-disable-next-line camelcase
+    metrics_collected: {
+        cpu: MetricDefinition,
+        disk: MetricDefinition,
+        diskio: MetricDefinition,
+        mem: MetricDefinition,
+        net: MetricDefinition,
+    };
+}
+
+/**
+ * Cloudwatch configuration - Metrics Section
+ *
+ * See definition at https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-Configuration-File-Details.html#CloudWatch-Agent-Configuration-File-Metricssection
+ *
+ * Example configuration:
+ * ```
+ * metrics: {
+ *   metrics_collected: {
+ *       "cpu": {
+ *         "measurement": [
+ *           "cpu_usage_idle",
+ *           "cpu_usage_nice",
+ *           "cpu_usage_guest",
+ *         ],
+ *       },
+ *   }
+ *   metrics_collection_interval: 60, // seconds between collections
+ * }
+ * ```
+ */
+export type CloudwatchMetricsSection = Readonly<EditableCloudwatchMetricsSection>;

--- a/lib/infra/infra-stack.ts
+++ b/lib/infra/infra-stack.ts
@@ -325,6 +325,36 @@ export class InfraStack extends Stack {
             omit_hostname: true,
             debug: false,
           },
+          metrics: {
+            metrics_collected: {
+              cpu: {
+                measurement: [
+                  // eslint-disable-next-line max-len
+                  'usage_active', 'usage_guest', 'usage_guest_nice', 'usage_idle', 'usage_iowait', 'usage_irq', 'usage_nice', 'usage_softirq', 'usage_steal', 'usage_system', 'usage_user', 'time_active', 'time_iowait', 'time_system', 'time_user'
+                ],
+              },
+              disk: {
+                measurement: [
+                  'free', 'total', 'used', 'used_percent', 'inodes_free', 'inodes_used', 'inodes_total',
+                ],
+              },
+              diskio: {
+                measurement: [
+                  'reads', 'writes', 'read_bytes', 'write_bytes', 'read_time', 'write_time', 'io_time',
+                ],
+              },
+              mem: {
+                measurement: [
+                  'active', 'available', 'available_percent', 'buffered', 'cached', 'free', 'inactive', 'total', 'used', 'used_percent',
+                ],
+              },
+              net: {
+                measurement: [
+                  'bytes_sent', 'bytes_recv', 'drop_in', 'drop_out', 'err_in', 'err_out', 'packets_sent', 'packets_recv',
+                ],
+              },
+            },
+          },
           logs: {
             logs_collected: {
               files: {


### PR DESCRIPTION
Signed-off-by: Suraj Singh <surajrider@gmail.com>

### Description
This change adds `metrics` section inside CloudWatch agent configuration file that allows agent to emit below os level metrics to CloudWatch service under `CWAgent` namespace.
1. cpu
2. disk
3. diskio
4. net
5. mem

### Issues Resolved
NA

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
