### PR TITLE
Inclusive naming changes

### DIFF
--- a/lib/opensearch-config/multi-node-base-config.yml
+++ b/lib/opensearch-config/multi-node-base-config.yml
@@ -1,5 +1,5 @@
 cluster.name: "opensearch"
-cluster.initial_master_nodes: ["seed"]
+cluster.initial_cluster_manager_nodes: ["seed"]
 discovery.seed_providers: ec2
 discovery.ec2.tag.role: manager
 network.host: 0.0.0.0

--- a/lib/opensearch-config/node-config.ts
+++ b/lib/opensearch-config/node-config.ts
@@ -8,38 +8,26 @@ compatible open source license. */
 export const nodeConfig = new Map<string, object>();
 
 nodeConfig.set('manager', {
-  'node.name': 'manager-node',
-  'node.master': true,
-  'node.data': false,
-  'node.ingest': false,
+  'node.roles': [ 'cluster_manager' ]
 });
 
 nodeConfig.set('data', {
-  'node.name': 'data-node',
-  'node.master': false,
-  'node.data': true,
-  'node.ingest': true,
+  'node.roles': [ 'data', 'ingest' ]
 });
 
 nodeConfig.set('seed-manager', {
   'node.name': 'seed',
-  'node.master': true,
-  'node.data': false,
-  'node.ingest': false,
+  'node.roles': [ 'cluster_manager' ]
 });
 
 nodeConfig.set('seed-data', {
   'node.name': 'seed',
-  'node.master': true,
-  'node.data': true,
-  'node.ingest': false,
+  'node.roles': [ 'cluster_manager', 'data' ]
 });
 
 nodeConfig.set('client', {
   'node.name': 'client-node',
-  'node.master': false,
-  'node.data': false,
-  'node.ingest': false,
+  'node.roles': []
 });
 
 nodeConfig.set('ml', {


### PR DESCRIPTION
### Description
1. Removes deprecated `master` role and uses `cluster-manager`. It does this by removing the deprecated setting `master.role` and instead uses `node.roles` setting it to cluster-manager.
2. Removes node-name param which is problematic for multi node cluster

### Issues Resolved
https://github.com/opensearch-project/opensearch-cluster-cdk/issues/16
https://github.com/opensearch-project/opensearch-cluster-cdk/issues/17

### Testing
Verified this for 3 data node cluster. 
Before change
```
➜  opensearch-cluster-cdk git:(metrics_update) ✗ curl OpenS-publi-KYVZ4M9OCI6O-fb4590773b32fef9.elb.us-west-2.amazonaws.com/_cat/nodes  

{"error":{"root_cause":[{"type":"cluster_manager_not_discovered_exception","reason":null}],"type":"cluster_manager_not_discovered_exception","reason":null},"status":503}%                                                                                ➜
```

After change
```
➜  opensearch-cluster-cdk git:(inclusive_naming_changes) ✗ curl  OpenS-publi-KYVZ4M9OCI6O-fb4590773b32fef9.elb.us-west-2.amazonaws.com/_cat/nodes                                                                     
10.0.4.82  19 67 0 0.03 0.15 0.08 di data,ingest     - ip-10-0-4-82.us-west-2.compute.internal
10.0.5.189 24 68 0 0.03 0.16 0.09 m  cluster_manager - ip-10-0-5-189.us-west-2.compute.internal
10.0.3.66  25 67 0 0.00 0.08 0.06 di data,ingest     - ip-10-0-3-66.us-west-2.compute.internal
10.0.5.32  16 66 0 0.14 0.21 0.09 di data,ingest     - ip-10-0-5-32.us-west-2.compute.internal
10.0.4.56  30 67 0 0.00 0.12 0.08 m  cluster_manager - ip-10-0-4-56.us-west-2.compute.internal
10.0.3.40  58 67 0 0.00 0.11 0.08 m  cluster_manager * seed
➜
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
