### PR TITLE
Make OSD optional and other minor improvements

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,40 @@
+---
+name: Backport
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    name: Backport
+    runs-on: ubuntu-latest
+    # Only react to merged PRs for security reasons.
+    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
+    if: >
+      github.event.pull_request.merged
+      && (
+        github.event.action == 'closed'
+        || (
+          github.event.action == 'labeled'
+          && contains(github.event.label.name, 'backport')
+        )
+      )
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: GitHub App token
+        id: github_app_token
+        uses: tibdex/github-app-token@v1.5.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          installation_id: 22958780
+
+      - name: Backport
+        uses: VachaShah/backport@v2.1.0
+        with:
+          github_token: ${{ steps.github_app_token.outputs.token }}
+          head_template: backport/backport-<%= number %>-to-<%= base %>

--- a/.github/workflows/delete-backport-branch.yml
+++ b/.github/workflows/delete-backport-branch.yml
@@ -1,0 +1,16 @@
+---
+name: Delete merged branch of the backport PRs
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  delete-branch:
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.pull_request.head.ref,'backport/')
+    steps:
+      - name: Delete merged branch
+        uses: SvanBoxel/delete-merged-branch@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ In order to deploy both the stacks the user needs to provide a set of required a
 | securityDisabled (required)       | boolean | Enable or disable security plugin                                                                                                                                        |
 | minDistribution (required)        | boolean | Is it the minimal OpenSearch distribution with no security and plugins                                                                                                   |
 | distributionUrl (required)        | string  | OpenSearch tar distribution url                                                                                                                                          |
-| dashboardsUrl (required)          | string  | OpenSearch Dashboards tar distribution url                                                                                                                               |
 | cpuArch (required)                | string  | CPU platform for EC2, could be either `x64` or `arm64`                                                                                                                   |
 | singleNodeCluster (required)      | boolean | Set `true` for single-node cluster else `false` for multi-node                                                                                                           |
 | serverAccessType (required)       | string  | Restrict server access based on ip address (ipv4/ipv6), prefix list and/or security group. See [Restricting Server Access](#restricting-server-access) for more details. |
 | restrictServerAccessTo (required) | string  | The value for `serverAccessType`, e.g., 10.10.10.10/32, pl-12345, sg-12345. See [Restricting Server Access](#restricting-server-access) for more details.                |
+| dashboardsUrl (Optional)          | string  | OpenSearch Dashboards tar distribution url                                                                                                                               |
 | vpcId (Optional)                  | string  | Re-use existing vpc, provide vpc id                                                                                                                                      |
 | securityGroupId (Optional)        | boolean | Re-use existing security group, provide security group id                                                                                                                |
 | cidr (Optional)                   | string  | User provided CIDR block for new Vpc, default is `10.0.0.0/16`                                                                                                           |
@@ -52,6 +52,12 @@ In order to deploy both the stacks the user needs to provide a set of required a
 | ingestNodeCount (Optional)        | integer | Number of dedicated ingest nodes, default is 0                                                                                                                           |
 | mlNodeCount (Optional)            | integer | Number of dedicated machine learning nodes, default is 0                                                                                                                 |
 | jvmSysProps (Optional)            | string  | A comma-separated list of key=value pairs that will be added to `jvm.options` as JVM system properties.                                                                  |
+| suffix (Optional)                 | string  | An optional string identifier to be concatenated with infra stack name.                                                                                                  |
+| region (Optional)                 | string  | User provided aws region                                                                                                                                                 |
+| account (Optional)                | string  | User provided aws account                                                                                                                                                |
+| dataNodeStorage (Optional)        | string  | User provided ebs block storage size, defaults to 100Gb                                                                                                                  |
+| mlNodeStorage (Optional)          | string  | User provided ebs block storage size, defaults to 100Gb                                                                                                                  |
+
 
 * Before starting this step, ensure that your AWS CLI is correctly configured with access credentials.
 * Also ensure that you're running these commands in the current directory

--- a/bin/app.ts
+++ b/bin/app.ts
@@ -11,7 +11,9 @@ import { App } from 'aws-cdk-lib';
 import { OsClusterEntrypoint } from '../lib/os-cluster-entrypoint';
 
 const app = new App();
+const region = app.node.tryGetContext('region') ?? process.env.CDK_DEFAULT_REGION;
+const account = app.node.tryGetContext('account') ?? process.env.CDK_DEFAULT_ACCOUNT;
 
 new OsClusterEntrypoint(app, {
-  env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
+  env: { account, region },
 });

--- a/lib/cloudwatch/cloudwatch-agent.ts
+++ b/lib/cloudwatch/cloudwatch-agent.ts
@@ -8,7 +8,7 @@ compatible open source license. */
 import { InitFile, InitFileOptions } from 'aws-cdk-lib/aws-ec2';
 import { CloudwatchAgentSection } from './agent-section';
 import { CloudwatchLogsSection } from './logs-section';
-import { CloudwatchMetricsSection } from "./metrics-section";
+import { CloudwatchMetricsSection } from './metrics-section';
 
 export interface CloudwatchAgentConfig {
     agent: CloudwatchAgentSection,


### PR DESCRIPTION
### Description
This PR adds following updates:
1. Makes OSD bring up optional. 
2. Replace single node setup with stand-alone ec2 rather than an ASG. 
3. Adds multi-az discovery support to NLB. 
4. Adds `region` and `account` optional parameters to let user select which account and region they want to bring up the cluster in. 
5. Adds `suffix` optional parameter to be added to infra stack name. This will help users spin up multiple OS clusters in the same region. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
