### PR TITLE
Scope discovery-ec2 IMDS lookups to this cluster formation.

### DIFF
--- a/lib/infra/infra-stack.ts
+++ b/lib/infra/infra-stack.ts
@@ -425,6 +425,10 @@ export class InfraStack extends Stack {
       const baseConfig: any = load(readFileSync(`${configFileDir}/multi-node-base-config.yml`, 'utf-8'));
 
       baseConfig['cluster.name'] = `${scope.stackName}-${scope.account}-${scope.region}`;
+
+      // use discovery-ec2 to find manager nodes by querying IMDS
+      baseConfig['discovery.ec2.tag.Name'] = `${scope.stackName}/seedNodeAsg,${scope.stackName}/managerNodeAsg`;
+
       const commonConfig = dump(baseConfig).toString();
       cfnInitConfig.push(InitCommand.shellCommand(`set -ex;cd opensearch; echo "${commonConfig}" > config/opensearch.yml`,
         {

--- a/lib/opensearch-config/multi-node-base-config.yml
+++ b/lib/opensearch-config/multi-node-base-config.yml
@@ -1,5 +1,4 @@
 cluster.name: "opensearch"
 cluster.initial_cluster_manager_nodes: ["seed"]
 discovery.seed_providers: ec2
-discovery.ec2.tag.role: manager
 network.host: 0.0.0.0


### PR DESCRIPTION
### Description

Scope discovery-ec2 IMDS lookups for seed/manager nodes down to this cluster. Here's a successful output.

```
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
|   timestamp   |                                                                                                                                                    message                                                                                                                                                     |
|---------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| 1686244606265 | [2023-06-08T17:16:46,146][DEBUG][o.o.d.e.AwsEc2SeedHostsProvider] [ip-10-0-5-156.ec2.internal] using host_type [private_ip], tags [{Name=[opensearch-infra-stack-270-multinode/seedNodeAsg, opensearch-infra-stack-270-multinode/managerNodeAsg]}], groups [[]] with any_group [true], availability_zones [[]] |
| 1686244608270 | [2023-06-08T17:16:48,118][TRACE][o.o.d.e.AwsEc2SeedHostsProvider] [ip-10-0-5-156.ec2.internal] finding seed nodes...                                                                                                                                                                                           |
| 1686244608270 | [2023-06-08T17:16:48,119][TRACE][o.o.d.e.AwsEc2SeedHostsProvider] [ip-10-0-5-156.ec2.internal] adding i-0e1b8f3a73ed4195b, address 10.0.4.146, transport_address 10.0.4.146:9300                                                                                                                               |
| 1686244608270 | [2023-06-08T17:16:48,119][TRACE][o.o.d.e.AwsEc2SeedHostsProvider] [ip-10-0-5-156.ec2.internal] adding i-0bad8a1561668117f, address 10.0.5.216, transport_address 10.0.5.216:9300                                                                                                                               |
| 1686244608270 | [2023-06-08T17:16:48,120][TRACE][o.o.d.e.AwsEc2SeedHostsProvider] [ip-10-0-5-156.ec2.internal] adding i-0a452e2dfdc05691f, address 10.0.3.33, transport_address 10.0.3.33:9300                                                                                                                                 |
| 1686244608520 | [2023-06-08T17:16:48,120][DEBUG][o.o.d.e.AwsEc2SeedHostsProvider] [ip-10-0-5-156.ec2.internal] using dynamic transport addresses [10.0.4.146:9300, 10.0.5.216:9300, 10.0.3.33:9300]                                                                                                                            |
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

I tried using `aws:cloudformation:stack-name`, but OpenSearch doesn't support settings named `discovery.ec2.tag.aws:cloudformation:stack-name`.

### Issues Resolved

Fixes #34.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
