### PR TITLE
Provide support to configure new instance types like r5.4xl/8xl, r6g.4xl/8xl and i3 instances

### DIFF
--- a/lib/infra/infra-stack.ts
+++ b/lib/infra/infra-stack.ts
@@ -22,7 +22,7 @@ import {
   SubnetType,
 } from 'aws-cdk-lib/aws-ec2';
 import { ManagedPolicy, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
-import { AutoScalingGroup, BlockDeviceVolume, Signals } from 'aws-cdk-lib/aws-autoscaling';
+import { AutoScalingGroup, BlockDeviceVolume, EbsDeviceVolumeType, Signals } from 'aws-cdk-lib/aws-autoscaling';
 import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import {
   CfnOutput, RemovalPolicy, Stack, StackProps, Tags,
@@ -60,7 +60,8 @@ export interface infraProps extends StackProps{
     readonly mlEc2InstanceType: InstanceType,
     readonly use50PercentHeap: boolean,
     readonly isInternal: boolean,
-    readonly enableRemoteStore: boolean
+    readonly enableRemoteStore: boolean,
+    readonly storageVolumeType: EbsDeviceVolumeType
 }
 
 export class InfraStack extends Stack {
@@ -144,7 +145,7 @@ export class InfraStack extends Stack {
         securityGroup: props.securityGroup,
         blockDevices: [{
           deviceName: '/dev/xvda',
-          volume: BlockDeviceVolume.ebs(props.dataNodeStorage, { deleteOnTermination: true }),
+          volume: BlockDeviceVolume.ebs(props.dataNodeStorage, { deleteOnTermination: true, volumeType: props.storageVolumeType }),
         }],
         init: CloudFormationInit.fromElements(...InfraStack.getCfnInitElement(this, clusterLogGroup, props)),
         initOptions: {
@@ -195,7 +196,7 @@ export class InfraStack extends Stack {
           securityGroup: props.securityGroup,
           blockDevices: [{
             deviceName: '/dev/xvda',
-            volume: BlockDeviceVolume.ebs(50, { deleteOnTermination: true }),
+            volume: BlockDeviceVolume.ebs(50, { deleteOnTermination: true, volumeType: props.storageVolumeType }),
           }],
           init: CloudFormationInit.fromElements(...InfraStack.getCfnInitElement(this, clusterLogGroup, props, 'manager')),
           initOptions: {
@@ -228,7 +229,7 @@ export class InfraStack extends Stack {
         blockDevices: [{
           deviceName: '/dev/xvda',
           // eslint-disable-next-line max-len
-          volume: (seedConfig === 'seed-manager') ? BlockDeviceVolume.ebs(50, { deleteOnTermination: true }) : BlockDeviceVolume.ebs(props.dataNodeStorage, { deleteOnTermination: true }),
+          volume: (seedConfig === 'seed-manager') ? BlockDeviceVolume.ebs(50, { deleteOnTermination: true, volumeType: props.storageVolumeType }) : BlockDeviceVolume.ebs(props.dataNodeStorage, { deleteOnTermination: true, volumeType: props.storageVolumeType }),
         }],
         init: CloudFormationInit.fromElements(...InfraStack.getCfnInitElement(this, clusterLogGroup, props, seedConfig)),
         initOptions: {
@@ -255,7 +256,7 @@ export class InfraStack extends Stack {
         securityGroup: props.securityGroup,
         blockDevices: [{
           deviceName: '/dev/xvda',
-          volume: BlockDeviceVolume.ebs(props.dataNodeStorage, { deleteOnTermination: true }),
+          volume: BlockDeviceVolume.ebs(props.dataNodeStorage, { deleteOnTermination: true, volumeType: props.storageVolumeType }),
         }],
         init: CloudFormationInit.fromElements(...InfraStack.getCfnInitElement(this, clusterLogGroup, props, 'data')),
         initOptions: {
@@ -285,7 +286,7 @@ export class InfraStack extends Stack {
           securityGroup: props.securityGroup,
           blockDevices: [{
             deviceName: '/dev/xvda',
-            volume: BlockDeviceVolume.ebs(50, { deleteOnTermination: true }),
+            volume: BlockDeviceVolume.ebs(50, { deleteOnTermination: true, volumeType: props.storageVolumeType }),
           }],
           init: CloudFormationInit.fromElements(...InfraStack.getCfnInitElement(this, clusterLogGroup, props, 'client')),
           initOptions: {
@@ -316,7 +317,7 @@ export class InfraStack extends Stack {
           securityGroup: props.securityGroup,
           blockDevices: [{
             deviceName: '/dev/xvda',
-            volume: BlockDeviceVolume.ebs(props.mlNodeStorage, { deleteOnTermination: true }),
+            volume: BlockDeviceVolume.ebs(props.mlNodeStorage, { deleteOnTermination: true, volumeType: props.storageVolumeType }),
           }],
           init: CloudFormationInit.fromElements(...InfraStack.getCfnInitElement(this, clusterLogGroup, props, 'ml')),
           initOptions: {

--- a/lib/opensearch-config/node-config.ts
+++ b/lib/opensearch-config/node-config.ts
@@ -6,6 +6,7 @@ this file be licensed under the Apache-2.0 license or a
 compatible open source license. */
 
 import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
+import { EbsDeviceVolumeType } from 'aws-cdk-lib/aws-autoscaling';
 
 export const nodeConfig = new Map<string, object>();
 
@@ -45,8 +46,15 @@ export enum x64Ec2InstanceType {
   R5_LARGE = 'r5.large',
   R5_XLARGE = 'r5.xlarge',
   R5_2XLARGE = 'r5.2xlarge',
+  R5_4XLARGE = 'r5.4xlarge',
+  R5_8XLARGE = 'r5.8xlarge',
   G5_LARGE = 'g5.large',
   G5_XLARGE = 'g5.xlarge',
+  I3_LARGE = 'i3.large',
+  I3_XLARGE = 'i3.xlarge',
+  I3_2XLARGE = 'i3.2xlarge',
+  I3_4XLARGE = 'i3.4xlarge',
+  I3_8XLARGE = 'i3.8xlarge',
   INF1_XLARGE = 'inf1.xlarge',
   INF1_2XLARGE = 'inf1.2xlarge'
 }
@@ -59,6 +67,8 @@ export enum arm64Ec2InstanceType {
   R6G_LARGE = 'r6g.large',
   R6G_XLARGE = 'r6g.xlarge',
   R6G_2XLARGE = 'r6g.2xlarge',
+  R6G_4XLARGE = 'r6g.4xlarge',
+  R6G_8XLARGE = 'r6g.8xlarge',
   G5G_LARGE = 'g5g.large',
   G5G_XLARGE = 'g5g.xlarge'
 }
@@ -79,10 +89,24 @@ export const getX64InstanceTypes = (instanceType: string) => {
     return InstanceType.of(InstanceClass.R5, InstanceSize.XLARGE);
   case x64Ec2InstanceType.R5_2XLARGE:
     return InstanceType.of(InstanceClass.R5, InstanceSize.XLARGE2);
+  case x64Ec2InstanceType.R5_4XLARGE:
+    return InstanceType.of(InstanceClass.R5, InstanceSize.XLARGE4);
+  case x64Ec2InstanceType.R5_8XLARGE:
+    return InstanceType.of(InstanceClass.R5, InstanceSize.XLARGE8);
   case x64Ec2InstanceType.G5_LARGE:
     return InstanceType.of(InstanceClass.G5, InstanceSize.LARGE);
   case x64Ec2InstanceType.G5_XLARGE:
     return InstanceType.of(InstanceClass.G5, InstanceSize.XLARGE);
+  case x64Ec2InstanceType.I3_LARGE:
+    return InstanceType.of(InstanceClass.I3, InstanceSize.LARGE);
+  case x64Ec2InstanceType.I3_XLARGE:
+    return InstanceType.of(InstanceClass.I3, InstanceSize.XLARGE);
+  case x64Ec2InstanceType.I3_2XLARGE:
+    return InstanceType.of(InstanceClass.I3, InstanceSize.XLARGE2);
+  case x64Ec2InstanceType.I3_4XLARGE:
+    return InstanceType.of(InstanceClass.I3, InstanceSize.XLARGE4);
+  case x64Ec2InstanceType.I3_8XLARGE:
+    return InstanceType.of(InstanceClass.I3, InstanceSize.XLARGE8);
   case x64Ec2InstanceType.INF1_XLARGE:
     return InstanceType.of(InstanceClass.INF1, InstanceSize.XLARGE);
   case x64Ec2InstanceType.INF1_2XLARGE:
@@ -108,11 +132,28 @@ export const getArm64InstanceTypes = (instanceType: string) => {
     return InstanceType.of(InstanceClass.R6G, InstanceSize.XLARGE);
   case arm64Ec2InstanceType.R6G_2XLARGE:
     return InstanceType.of(InstanceClass.R6G, InstanceSize.XLARGE2);
+  case arm64Ec2InstanceType.R6G_4XLARGE:
+    return InstanceType.of(InstanceClass.R6G, InstanceSize.XLARGE4);
+  case arm64Ec2InstanceType.R6G_8XLARGE:
+    return InstanceType.of(InstanceClass.R6G, InstanceSize.XLARGE8);
   case arm64Ec2InstanceType.G5G_LARGE:
     return InstanceType.of(InstanceClass.G5G, InstanceSize.LARGE);
   case arm64Ec2InstanceType.G5G_XLARGE:
     return InstanceType.of(InstanceClass.G5G, InstanceSize.XLARGE);
   default:
     throw new Error(`Invalid instance type provided, please provide any one the following: ${Object.values(arm64Ec2InstanceType)}`);
+  }
+};
+
+export const getVolumeType = (volumeType: string) => {
+  switch (volumeType) {
+  case EbsDeviceVolumeType.STANDARD.valueOf():
+    return EbsDeviceVolumeType.STANDARD;
+  case EbsDeviceVolumeType.GP2.valueOf():
+    return EbsDeviceVolumeType.GP2;
+  case EbsDeviceVolumeType.GP3.valueOf():
+    return EbsDeviceVolumeType.GP3;
+  default:
+    throw new Error('Invalid volume type provided, please provide any one of the following: standard, gp2, gp3');
   }
 };


### PR DESCRIPTION
### Description
Add support for more instance types and GP3 EBS volume type for cluster setup. New parameter for EBS volume is `--context storageVolumeType=gp3/gp2/standard`. Will update the doc post merge of the PR

Have tested and verified that gp3 is configured correctly for different instances.

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
