### PR TITLE
Enable IMDSv2 on all instances

### DIFF
--- a/lib/infra/infra-stack.ts
+++ b/lib/infra/infra-stack.ts
@@ -6,9 +6,17 @@ this file be licensed under the Apache-2.0 license or a
 compatible open source license. */
 
 import {
+  CfnOutput, RemovalPolicy, Stack, StackProps, Tags,
+} from 'aws-cdk-lib';
+import {
+  AutoScalingGroup, BlockDeviceVolume, EbsDeviceVolumeType, Signals,
+} from 'aws-cdk-lib/aws-autoscaling';
+import {
   AmazonLinuxCpuType,
   AmazonLinuxGeneration,
   CloudFormationInit,
+  ISecurityGroup,
+  IVpc,
   InitCommand,
   InitElement,
   InitPackage,
@@ -16,24 +24,16 @@ import {
   InstanceClass,
   InstanceSize,
   InstanceType,
-  ISecurityGroup,
-  IVpc,
   MachineImage,
   SubnetType,
 } from 'aws-cdk-lib/aws-ec2';
-import { ManagedPolicy, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
-import {
-  AutoScalingGroup, BlockDeviceVolume, EbsDeviceVolumeType, Signals,
-} from 'aws-cdk-lib/aws-autoscaling';
-import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
-import {
-  CfnOutput, RemovalPolicy, Stack, StackProps, Tags,
-} from 'aws-cdk-lib';
 import { NetworkListener, NetworkLoadBalancer, Protocol } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
-import { join } from 'path';
+import { InstanceTarget } from 'aws-cdk-lib/aws-elasticloadbalancingv2-targets';
+import { ManagedPolicy, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { readFileSync } from 'fs';
 import { dump, load } from 'js-yaml';
-import { InstanceTarget } from 'aws-cdk-lib/aws-elasticloadbalancingv2-targets';
+import { join } from 'path';
 import { CloudwatchAgent } from '../cloudwatch/cloudwatch-agent';
 import { nodeConfig } from '../opensearch-config/node-config';
 import { RemoteStoreResources } from './remote-store-resources';
@@ -153,6 +153,7 @@ export class InfraStack extends Stack {
         initOptions: {
           ignoreFailures: false,
         },
+        requireImdsv2: true,
       });
       Tags.of(singleNodeInstance).add('role', 'client');
 
@@ -204,6 +205,7 @@ export class InfraStack extends Stack {
           initOptions: {
             ignoreFailures: false,
           },
+          requireImdsv2: true,
           signals: Signals.waitForAll(),
         });
         Tags.of(managerNodeAsg).add('role', 'manager');
@@ -237,6 +239,7 @@ export class InfraStack extends Stack {
         initOptions: {
           ignoreFailures: false,
         },
+        requireImdsv2: true,
         signals: Signals.waitForAll(),
       });
       Tags.of(seedNodeAsg).add('role', 'manager');
@@ -264,6 +267,7 @@ export class InfraStack extends Stack {
         initOptions: {
           ignoreFailures: false,
         },
+        requireImdsv2: true,
         signals: Signals.waitForAll(),
       });
       Tags.of(dataNodeAsg).add('role', 'data');
@@ -294,6 +298,7 @@ export class InfraStack extends Stack {
           initOptions: {
             ignoreFailures: false,
           },
+          requireImdsv2: true,
           signals: Signals.waitForAll(),
         });
         Tags.of(clientNodeAsg).add('cluster', scope.stackName);
@@ -325,6 +330,7 @@ export class InfraStack extends Stack {
           initOptions: {
             ignoreFailures: false,
           },
+          requireImdsv2: true,
           signals: Signals.waitForAll(),
         });
 

--- a/test/os-cluster.test.ts
+++ b/test/os-cluster.test.ts
@@ -71,6 +71,11 @@ test('Test Resources with security disabled multi-node default instance types', 
       Ref: 'managerNodeAsgInstanceProfile1415C2CF',
     },
   });
+  infraTemplate.hasResourceProperties('AWS::AutoScaling::LaunchConfiguration', {
+    MetadataOptions: {
+      HttpTokens: 'required',
+    },
+  });
 });
 
 test('Test Resources with security enabled multi-node with existing Vpc with user provided data and ml instance types', () => {
@@ -142,6 +147,11 @@ test('Test Resources with security enabled multi-node with existing Vpc with use
     InstanceType: 'g5.xlarge',
     IamInstanceProfile: {
       Ref: 'mlNodeAsgInstanceProfileFF393D8C',
+    },
+  });
+  infraTemplate.hasResourceProperties('AWS::AutoScaling::LaunchConfiguration', {
+    MetadataOptions: {
+      HttpTokens: 'required',
     },
   });
 });
@@ -306,6 +316,11 @@ test('Test multi-node cluster with only data-nodes', () => {
         },
       },
     ],
+  });
+  infraTemplate.hasResourceProperties('AWS::AutoScaling::LaunchConfiguration', {
+    MetadataOptions: {
+      HttpTokens: 'required',
+    },
   });
 });
 


### PR DESCRIPTION
### Description
Enabling IMDSv2 on all nodes by default in order to have more secure calls. Read more about it https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
