### PR TITLE
Fix the default instance type issue for single node domain creation

### DIFF
--- a/lib/infra/infra-stack.ts
+++ b/lib/infra/infra-stack.ts
@@ -100,8 +100,14 @@ export class InfraStack extends Stack {
       this.instanceRole.addToPolicy(remoteStoreObj.getRemoteStoreBucketPolicy());
     }
 
-    const singleNodeInstanceType = (props.cpuType === AmazonLinuxCpuType.X86_64)
-      ? InstanceType.of(InstanceClass.R5, InstanceSize.XLARGE) : InstanceType.of(InstanceClass.R6G, InstanceSize.XLARGE);
+    let singleNodeInstanceType: InstanceType;
+    if (props.dataEc2InstanceType) {
+      singleNodeInstanceType = props.dataEc2InstanceType;
+    } else if (props.cpuType === AmazonLinuxCpuType.X86_64) {
+      singleNodeInstanceType = InstanceType.of(InstanceClass.R5, InstanceSize.XLARGE) ;
+    } else {
+      singleNodeInstanceType = InstanceType.of(InstanceClass.R6G, InstanceSize.XLARGE);
+    }
 
     const defaultInstanceType = (props.cpuType === AmazonLinuxCpuType.X86_64)
       ? InstanceType.of(InstanceClass.C5, InstanceSize.XLARGE) : InstanceType.of(InstanceClass.C6G, InstanceSize.XLARGE);

--- a/test/os-cluster.test.ts
+++ b/test/os-cluster.test.ts
@@ -160,6 +160,7 @@ test('Test Resources with security enabled single-node cluster', () => {
       restrictServerAccessTo: 'pl-12345',
       dataNodeStorage: 200,
       isInternal: true,
+      dataInstanceType: 'r5.large',
       storageVolumeType: 'gp3',
     },
   });
@@ -185,6 +186,7 @@ test('Test Resources with security enabled single-node cluster', () => {
   infraTemplate.resourceCountIs('AWS::ElasticLoadBalancingV2::Listener', 2);
   infraTemplate.resourceCountIs('AWS::ElasticLoadBalancingV2::TargetGroup', 2);
   infraTemplate.hasResourceProperties('AWS::EC2::Instance', {
+    InstanceType: 'r5.large',
     BlockDeviceMappings: [
       {
         Ebs: {


### PR DESCRIPTION
### Description
With the current implementation, single node creation will consistently use either `r5.xlarge` or `r6g.xlarge` without considering the input parameter. This PR aims to address this issue, enabling the customization of the single node instance type.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
