### PR TITLE
Add region key to node attr setting for remote-store

### DIFF
--- a/lib/infra/infra-stack.ts
+++ b/lib/infra/infra-stack.ts
@@ -22,7 +22,9 @@ import {
   SubnetType,
 } from 'aws-cdk-lib/aws-ec2';
 import { ManagedPolicy, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
-import { AutoScalingGroup, BlockDeviceVolume, EbsDeviceVolumeType, Signals } from 'aws-cdk-lib/aws-autoscaling';
+import {
+  AutoScalingGroup, BlockDeviceVolume, EbsDeviceVolumeType, Signals,
+} from 'aws-cdk-lib/aws-autoscaling';
 import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import {
   CfnOutput, RemovalPolicy, Stack, StackProps, Tags,
@@ -486,7 +488,13 @@ export class InfraStack extends Stack {
         }
 
         // eslint-disable-next-line max-len
-        cfnInitConfig.push(InitCommand.shellCommand(`set -ex;cd opensearch; echo "cluster.remote_store.repository: ${scope.stackName}-repo" >> config/opensearch.yml`, {
+        cfnInitConfig.push(InitCommand.shellCommand(`set -ex;cd opensearch; echo "cluster.remote_store.segment.repository: ${scope.stackName}-repo" >> config/opensearch.yml`, {
+          cwd: '/home/ec2-user',
+          ignoreErrors: false,
+        }));
+
+        // eslint-disable-next-line max-len
+        cfnInitConfig.push(InitCommand.shellCommand(`set -ex;cd opensearch; echo "cluster.remote_store.translog.repository: ${scope.stackName}-repo" >> config/opensearch.yml`, {
           cwd: '/home/ec2-user',
           ignoreErrors: false,
         }));

--- a/lib/infra/infra-stack.ts
+++ b/lib/infra/infra-stack.ts
@@ -512,7 +512,7 @@ export class InfraStack extends Stack {
         }));
 
         // eslint-disable-next-line max-len
-        cfnInitConfig.push(InitCommand.shellCommand(`set -ex;cd opensearch; echo "node.attr.remote_store.repository.${scope.stackName}-repo.settings:\n  bucket : ${scope.stackName}\n  base_path: remote-store" >> config/opensearch.yml`, {
+        cfnInitConfig.push(InitCommand.shellCommand(`set -ex;cd opensearch; echo "node.attr.remote_store.repository.${scope.stackName}-repo.settings:\n  bucket : ${scope.stackName}\n  base_path: remote-store\n  region: ${scope.region}" >> config/opensearch.yml`, {
           cwd: '/home/ec2-user',
           ignoreErrors: false,
         }));


### PR DESCRIPTION
### Description
Related to https://github.com/opensearch-project/OpenSearch/issues/9942. 
Add `region` key to avoid indexing failure while using remote-store feature. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
