### PR TITLE
Add security plugin directory check

### DIFF
--- a/lib/infra/infra-stack.ts
+++ b/lib/infra/infra-stack.ts
@@ -533,7 +533,8 @@ export class InfraStack extends Stack {
 
     // add config to disable security if required
     if (props.securityDisabled && !props.minDistribution) {
-      cfnInitConfig.push(InitCommand.shellCommand('set -ex;cd opensearch; echo "plugins.security.disabled: true" >> config/opensearch.yml',
+      // eslint-disable-next-line max-len
+      cfnInitConfig.push(InitCommand.shellCommand('set -ex;cd opensearch; if [ -d "/home/ec2-user/opensearch/plugins/opensearch-security" ]; then echo "plugins.security.disabled: true" >> config/opensearch.yml; fi',
         {
           cwd: '/home/ec2-user',
           ignoreErrors: false,


### PR DESCRIPTION
### Description
The cluster formation fails when the security plugin is not present in the bundle distribution. This is because we are not checking the presence of security plugin [here](https://github.com/opensearch-project/opensearch-cluster-cdk/blob/main/lib/infra/infra-stack.ts#L535-L541) and adding the security disable settings. 
This PR adds check for the presence of security plugin before adding the disable settings. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
