### PR TITLE
Fix typo - remove additional space

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ cdk bootstrap aws://<aws-account-number>/<aws-region> --context securityDisabled
 * Now you are ready to synthesize the CloudFormation templates:
 
 ```
-cdk synth "* " --context securityDisabled=false \
+cdk synth "*" --context securityDisabled=false \
 --context minDistribution=false --context distributionUrl='https://artifacts.opensearch.org/releases/bundle/opensearch/2.3.0/opensearch-2.3.0-linux-x64.tar.gz' \
 --context cpuArch='x64' --context singleNodeCluster=false --context dataNodeCount=3 \
 --context dashboardsUrl='https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/2.3.0/opensearch-dashboards-2.3.0-linux-x64.tar.gz' \


### PR DESCRIPTION
### Description
_Minor typo fix because of additional space character in Readme._

Error because of existing extra space:
```
cdk synth "* " --context securityDisabled=true \
--context minDistribution=false --context distributionUrl='https://artifacts.opensearch.org/releases/bundle/opensearch/2.11.0/opensearch-2.11.0-linux-x64.tar.gz' \
--context cpuArch='x64' --context singleNodeCluster=false --context dataNodeCount=3 \
--context dashboardsUrl='https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/2.11.0/opensearch-dashboards-2.11.0-linux-x64.tar.gz' \
--context distVersion=2.11.0 --context serverAccessType=ipv4 --context restrictServerAccessTo=10.10.10.10/32
No VPC Provided, creating new
[WARNING] aws-cdk-lib.aws_ec2.VpcProps#cidr is deprecated.
  Use ipAddresses instead
  This API will be removed in the next major release.
[WARNING] aws-cdk-lib.aws_ec2.MachineImage#latestAmazonLinux is deprecated.
  use MachineImage.latestAmazonLinux2 instead
  This API will be removed in the next major release.
[WARNING] aws-cdk-lib.aws_ec2.MachineImage#latestAmazonLinux is deprecated.
  use MachineImage.latestAmazonLinux2 instead
  This API will be removed in the next major release.
[WARNING] aws-cdk-lib.aws_ec2.MachineImage#latestAmazonLinux is deprecated.
  use MachineImage.latestAmazonLinux2 instead
  This API will be removed in the next major release.

No stacks match the name(s) *
```

Just removing the extra space so that folks setting up first time don't spend unnecessary time debugging this error.

### Issues Resolved
_None._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
