### PR TITLE
make repository-s3 plugin installation default

### DIFF
--- a/lib/infra/infra-stack.ts
+++ b/lib/infra/infra-stack.ts
@@ -483,20 +483,10 @@ export class InfraStack extends Stack {
           cwd: '/home/ec2-user',
           ignoreErrors: false,
         }));
-        cfnInitConfig.push(InitCommand.shellCommand('set -ex;cd opensearch;sudo -u ec2-user bin/opensearch-plugin install repository-s3 --batch', {
-          cwd: '/home/ec2-user',
-          ignoreErrors: false,
-        }));
       } else {
         cfnInitConfig.push(InitCommand.shellCommand('set -ex;cd opensearch;sudo -u ec2-user bin/opensearch-plugin install '
           + `https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${props.opensearchVersion}/latest/linux/${props.cpuArch}`
           + `/tar/builds/opensearch/core-plugins/discovery-ec2-${props.opensearchVersion}.zip --batch`, {
-          cwd: '/home/ec2-user',
-          ignoreErrors: false,
-        }));
-        cfnInitConfig.push(InitCommand.shellCommand('set -ex;cd opensearch;sudo -u ec2-user bin/opensearch-plugin install '
-          + `https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${props.opensearchVersion}/latest/linux/${props.cpuArch}`
-          + `/tar/builds/opensearch/core-plugins/repository-s3-${props.opensearchVersion}.zip --batch`, {
           cwd: '/home/ec2-user',
           ignoreErrors: false,
         }));
@@ -533,6 +523,20 @@ export class InfraStack extends Stack {
           ignoreErrors: false,
         }));
       }
+    }
+
+    if (props.distributionUrl.includes('artifacts.opensearch.org') && !props.minDistribution) {
+      cfnInitConfig.push(InitCommand.shellCommand('set -ex;cd opensearch;sudo -u ec2-user bin/opensearch-plugin install repository-s3 --batch', {
+        cwd: '/home/ec2-user',
+        ignoreErrors: false,
+      }));
+    } else {
+      cfnInitConfig.push(InitCommand.shellCommand('set -ex;cd opensearch;sudo -u ec2-user bin/opensearch-plugin install '
+          + `https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${props.opensearchVersion}/latest/linux/${props.cpuArch}`
+          + `/tar/builds/opensearch/core-plugins/repository-s3-${props.opensearchVersion}.zip --batch`, {
+        cwd: '/home/ec2-user',
+        ignoreErrors: false,
+      }));
     }
 
     // add config to disable security if required


### PR DESCRIPTION
### Description
Currently `repository-s3` plugin is only installed if it is multi-node cluster but single-node cluster might also need to upload and fetch snapshots. This PR makes repository-s3 plugin installation default. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
