### PR TITLE
Move all checks and default values for network stack to NetworkStack class

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -6,8 +6,8 @@ The OpenSearch Contributors require contributions made to
 this file be licensed under the Apache-2.0 license or a
 compatible open source license. */
 
-import 'source-map-support/register';
 import { App } from 'aws-cdk-lib';
+import 'source-map-support/register';
 import { OsClusterEntrypoint } from '../lib/os-cluster-entrypoint';
 
 const app = new App();

--- a/lib/networking/vpc-stack.ts
+++ b/lib/networking/vpc-stack.ts
@@ -34,17 +34,17 @@ export class NetworkStack extends Stack {
 
   constructor(scope: Construct, id: string, props: VpcProps) {
     super(scope, id, props);
-    
+
     let serverAccess: IPeer;
     // Properties and context variables check
     let cidrRange = `${props?.cidr ?? scope.node.tryGetContext('cidr')}`;
-    if (cidrRange == 'undefined'){
-      cidrRange = '10.0.0.0/16'
+    if (cidrRange === 'undefined') {
+      cidrRange = '10.0.0.0/16';
     }
-    let vpcId = `${props?.vpcId ?? scope.node.tryGetContext('vpcId')}`;
-    let serverAccessType = `${props?.serverAccessType ?? scope.node.tryGetContext('serverAccessType')}`
-    let restrictServerAccessTo = `${props?.restrictServerAccessTo ?? scope.node.tryGetContext('restrictServerAccessTo')}`
-    let secGroupId = `${props?.securityGroupId ?? scope.node.tryGetContext('securityGroupId')}`
+    const vpcId = `${props?.vpcId ?? scope.node.tryGetContext('vpcId')}`;
+    const serverAccessType = `${props?.serverAccessType ?? scope.node.tryGetContext('serverAccessType')}`;
+    const restrictServerAccessTo = `${props?.restrictServerAccessTo ?? scope.node.tryGetContext('restrictServerAccessTo')}`;
+    const secGroupId = `${props?.securityGroupId ?? scope.node.tryGetContext('securityGroupId')}`;
 
     if (typeof restrictServerAccessTo === 'undefined' || typeof serverAccessType === 'undefined') {
       throw new Error('serverAccessType and restrictServerAccessTo parameters are required - eg: serverAccessType=ipv4 restrictServerAccessTo=10.10.10.10/32');
@@ -74,7 +74,7 @@ export class NetworkStack extends Stack {
     } else {
       console.log('VPC provided, using existing');
       this.vpc = Vpc.fromLookup(this, 'opensearchClusterVpc', {
-        vpcId: vpcId,
+        vpcId,
       });
     }
 

--- a/lib/os-cluster-entrypoint.ts
+++ b/lib/os-cluster-entrypoint.ts
@@ -69,11 +69,6 @@ export class OsClusterEntrypoint {
 
       const x64InstanceTypes: string[] = Object.keys(x64Ec2InstanceType);
       const arm64InstanceTypes: string[] = Object.keys(arm64Ec2InstanceType);
-      const vpcId: string = scope.node.tryGetContext('vpcId');
-      const securityGroupId = scope.node.tryGetContext('securityGroupId');
-      const cidrRange = scope.node.tryGetContext('cidr');
-      const restrictServerAccessTo = scope.node.tryGetContext('restrictServerAccessTo');
-      const serverAccessType = scope.node.tryGetContext('serverAccessType');
 
       const distVersion = `${scope.node.tryGetContext('distVersion')}`;
       if (distVersion.toString() === 'undefined') {
@@ -233,12 +228,6 @@ export class OsClusterEntrypoint {
       }
 
       const network = new NetworkStack(scope, networkStackName, {
-        cidrBlock: cidrRange,
-        maxAzs: 3,
-        vpcId,
-        securityGroupId,
-        serverAccessType,
-        restrictServerAccessTo,
         ...props,
       });
 


### PR DESCRIPTION
### Description
In order to make the checks more compatible with props as well as context variables, moving the checks and default values to NetworkStack Class. I tested the behavior with existing stack and it showed no changes. 
Also removed `maxAzs` property as it was not being used as network stack was always called with hard coded value to `3`.

This is the first iteration of clean up. See linked issue below for whys.

### Issues Resolved
#75  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
