### PR TITLE
Fix the semver version check for adminPassword props

### DIFF
--- a/lib/infra/infra-stack.ts
+++ b/lib/infra/infra-stack.ts
@@ -38,6 +38,7 @@ import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { readFileSync } from 'fs';
 import { dump, load } from 'js-yaml';
 import { join } from 'path';
+import { satisfies } from 'semver';
 import { CloudwatchAgent } from '../cloudwatch/cloudwatch-agent';
 import { ProcstatMetricDefinition } from '../cloudwatch/metrics-section';
 import { InfraStackMonitoring } from '../monitoring/alarms';
@@ -206,7 +207,7 @@ export class InfraStack extends Stack {
     this.securityDisabled = securityDisabled === 'true';
 
     this.adminPassword = this.securityDisabled ? '' : `${props?.adminPassword ?? scope.node.tryGetContext('adminPassword')}`;
-    if (!this.securityDisabled && Number.parseFloat(this.distVersion) >= 2.12 && this.adminPassword === 'undefined') {
+    if (!this.securityDisabled && satisfies(this.distVersion, '>=2.12.0') && this.adminPassword === 'undefined') {
       throw new Error('adminPassword parameter is required to be set when security is enabled');
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "eslint-config-airbnb-base": "^14.2.1",
         "eslint-plugin-import": "^2.24.2",
         "js-yaml": "^4.1.0",
+        "semver": "^7.5.4",
         "source-map-support": "^0.5.21"
       },
       "bin": {
@@ -26,6 +27,7 @@
         "@types/js-yaml": "^4.0.5",
         "@types/node": "10.17.27",
         "@types/prettier": "2.6.0",
+        "@types/semver": "^7.5.6",
         "aws-cdk": "2.45.0",
         "jest": "^27.5.1",
         "ts-jest": "^27.1.4",
@@ -1269,6 +1271,12 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.0.tgz",
       "integrity": "sha512-G/AdOadiZhnJp0jXCaBQU449W2h716OW/EoXeYkCytxKL06X1WCXB4DZpp8TpZ8eyIJVS1cw4lrlkkSYU21cDw==",
+      "dev": true
+    },
+    "node_modules/@types/semver": {
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
+      "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
       "dev": true
     },
     "node_modules/@types/stack-utils": {
@@ -5298,9 +5306,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -7218,6 +7226,12 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.0.tgz",
       "integrity": "sha512-G/AdOadiZhnJp0jXCaBQU449W2h716OW/EoXeYkCytxKL06X1WCXB4DZpp8TpZ8eyIJVS1cw4lrlkkSYU21cDw==",
+      "dev": true
+    },
+    "@types/semver": {
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
+      "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
       "dev": true
     },
     "@types/stack-utils": {
@@ -10138,9 +10152,9 @@
       }
     },
     "semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "requires": {
         "lru-cache": "^6.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
   },
   "devDependencies": {
     "@types/jest": "^27.5.2",
+    "@types/js-yaml": "^4.0.5",
     "@types/node": "10.17.27",
     "@types/prettier": "2.6.0",
-    "@types/js-yaml": "^4.0.5",
+    "@types/semver": "^7.5.6",
     "aws-cdk": "2.45.0",
     "jest": "^27.5.1",
     "ts-jest": "^27.1.4",
@@ -27,10 +28,11 @@
     "@typescript-eslint/parser": "^4.31.1",
     "aws-cdk-lib": "2.45.0",
     "constructs": "^10.0.0",
-    "js-yaml": "^4.1.0",
-    "source-map-support": "^0.5.21",
     "eslint": "^7.32.0",
     "eslint-config-airbnb-base": "^14.2.1",
-    "eslint-plugin-import": "^2.24.2"
+    "eslint-plugin-import": "^2.24.2",
+    "js-yaml": "^4.1.0",
+    "semver": "^7.5.6",
+    "source-map-support": "^0.5.21"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-plugin-import": "^2.24.2",
     "js-yaml": "^4.1.0",
-    "semver": "^7.5.6",
+    "semver": "^7.5.4",
     "source-map-support": "^0.5.21"
   }
 }

--- a/test/opensearch-cluster-cdk.test.ts
+++ b/test/opensearch-cluster-cdk.test.ts
@@ -736,3 +736,35 @@ test('Should not throw error when security is enabled and adminPassword is  defi
     env: { account: 'test-account', region: 'us-east-1' },
   });
 });
+
+test('Should not throw error when security is enabled and version is less than 2.12', () => {
+  const app = new App({
+    context: {
+      securityDisabled: false,
+      minDistribution: false,
+      distributionUrl: 'www.example.com',
+      cpuArch: 'x64',
+      singleNodeCluster: false,
+      dashboardsUrl: 'www.example.com',
+      distVersion: '2.4.0',
+      serverAccessType: 'ipv4',
+      restrictServerAccessTo: 'all',
+      managerNodeCount: 0,
+      dataNodeCount: 3,
+      dataNodeStorage: 200,
+      customRoleArn: 'arn:aws:iam::12345678:role/customRoleName',
+    },
+  });
+
+  // WHEN
+  const networkStack = new NetworkStack(app, 'opensearch-network-stack', {
+    env: { account: 'test-account', region: 'us-east-1' },
+  });
+
+  // @ts-ignore
+  const infraStack = new InfraStack(app, 'opensearch-infra-stack', {
+    vpc: networkStack.vpc,
+    securityGroup: networkStack.osSecurityGroup,
+    env: { account: 'test-account', region: 'us-east-1' },
+  });
+});


### PR DESCRIPTION
### Description
Fixes the logic to compare the versions as per sermver and not mathematically for requiring admin user and password. 

### Issues Resolved
resolves https://github.com/opensearch-project/opensearch-cluster-cdk/issues/90

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
