### PR TITLE
Publish all modules to npmjs

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,16 +18,30 @@ jobs:
         run: |
           echo "approvers=$(cat .github/CODEOWNERS | grep @ | tr -d '* ' | sed 's/@/,/g' | sed 's/,//1')" >> $GITHUB_OUTPUT
           echo "version=$(cat package.json | jq .version | tr -d "\"")" >> $GITHUB_OUTPUT
-      - uses: trstringer/manual-approval@v1
+      # - uses: trstringer/manual-approval@v1
+      #   with:
+      #     secret: ${{ github.TOKEN }}
+      #     approvers: ${{ steps.get_data.outputs.approvers }}
+      #     minimum-approvals: 2
+      #     issue-title: 'Release opensearch-cluster-cdk : ${{ steps.get_data.outputs.version }}'
+      #     issue-body: "Please approve or deny the release of opensearch-cluster-cdk. **VERSION**: ${{ steps.get_data.outputs.version }} **TAG**: ${{ github.ref_name }}  **COMMIT**: ${{ github.sha }}"
+      #     exclude-workflow-initiator-as-approver: true
+      - name: Set up node
+        uses: actions/setup-node@v3
         with:
-          secret: ${{ github.TOKEN }}
-          approvers: ${{ steps.get_data.outputs.approvers }}
-          minimum-approvals: 2
-          issue-title: 'Release opensearch-cluster-cdk : ${{ steps.get_data.outputs.version }}'
-          issue-body: "Please approve or deny the release of opensearch-cluster-cdk. **VERSION**: ${{ steps.get_data.outputs.version }} **TAG**: ${{ github.ref_name }}  **COMMIT**: ${{ github.sha }}"
-          exclude-workflow-initiator-as-approver: true
-      - name: Release
+          node-version: 16.16.0
+          registry-url: 'https://registry.npmjs.org'
+      - name: Build and package
+        run: |
+          npm install && npm run build
+          npm pack
+          filename=`ls | grep opensearch-project-opensearch-cluster-cdk`
+          mkdir publish-cluster-cdk && mv $filename publish-cluster-cdk/opensearch-cluster-cdk.tar.gz
+          tar -cvf artifacts.tar.gz publish-cluster-cdk
+      - name: Draft a release
         uses: softprops/action-gh-release@v1
         with:
           draft: true
           generate_release_notes: true
+          files: |
+            artifacts.tar.gz

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,14 +18,14 @@ jobs:
         run: |
           echo "approvers=$(cat .github/CODEOWNERS | grep @ | tr -d '* ' | sed 's/@/,/g' | sed 's/,//1')" >> $GITHUB_OUTPUT
           echo "version=$(cat package.json | jq .version | tr -d "\"")" >> $GITHUB_OUTPUT
-      # - uses: trstringer/manual-approval@v1
-      #   with:
-      #     secret: ${{ github.TOKEN }}
-      #     approvers: ${{ steps.get_data.outputs.approvers }}
-      #     minimum-approvals: 2
-      #     issue-title: 'Release opensearch-cluster-cdk : ${{ steps.get_data.outputs.version }}'
-      #     issue-body: "Please approve or deny the release of opensearch-cluster-cdk. **VERSION**: ${{ steps.get_data.outputs.version }} **TAG**: ${{ github.ref_name }}  **COMMIT**: ${{ github.sha }}"
-      #     exclude-workflow-initiator-as-approver: true
+      - uses: trstringer/manual-approval@v1
+        with:
+          secret: ${{ github.TOKEN }}
+          approvers: ${{ steps.get_data.outputs.approvers }}
+          minimum-approvals: 2
+          issue-title: 'Release opensearch-cluster-cdk : ${{ steps.get_data.outputs.version }}'
+          issue-body: "Please approve or deny the release of opensearch-cluster-cdk. **VERSION**: ${{ steps.get_data.outputs.version }} **TAG**: ${{ github.ref_name }}  **COMMIT**: ${{ github.sha }}"
+          exclude-workflow-initiator-as-approver: true
       - name: Set up node
         uses: actions/setup-node@v3
         with:

--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -6,6 +6,7 @@ lib = library(identifier: 'jenkins@6.0.0', retriever: modernSCM([
 standardReleasePipelineWithGenericTrigger(
     tokenIdCredential: 'jenkins-opensearch-cluster-cdk-generic-webhook-token',
     causeString: 'A tag was cut on opensearch-project/opensearch-cluster-cdk repository causing this workflow to run',
+    downloadReleaseAsset: true,
     publishRelease: true) {
         publishToNpm(
             publicationType: 'artifact',

--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -7,5 +7,8 @@ standardReleasePipelineWithGenericTrigger(
     tokenIdCredential: 'jenkins-opensearch-cluster-cdk-generic-webhook-token',
     causeString: 'A tag was cut on opensearch-project/opensearch-cluster-cdk repository causing this workflow to run',
     publishRelease: true) {
-        publishToNpm(publicationType: 'github')
+        publishToNpm(
+            publicationType: 'artifact',
+            artifactPath: "${WORKSPACE}/publish-cluster-cdk/opensearch-cluster-cdk.tar.gz"
+            )
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opensearch-project/opensearch-cluster-cdk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@opensearch-project/opensearch-cluster-cdk",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.31.1",
         "@typescript-eslint/parser": "^4.31.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensearch-project/opensearch-cluster-cdk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "bin": {
     "cdk_v2": "bin/app.js"
   },


### PR DESCRIPTION
### Description
The recent version of opsnearch-cluster-cdk does not publish all modules to npmjs causing the imports in extending package to be missing. 
<img width="723" alt="image" src="https://github.com/opensearch-project/opensearch-cluster-cdk/assets/61760125/02c9ee62-9313-4524-b8a2-facd92e7ad95">

This PR builds all the installable modules and publish the final tarball generated using npm-pack command. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
