### PR TITLE
Modify security group ingress rules to allow access only on specific ports

### DIFF
--- a/lib/networking/vpc-stack.ts
+++ b/lib/networking/vpc-stack.ts
@@ -90,7 +90,11 @@ export class NetworkStack extends Stack {
 
     /* The security group allows all ip access by default to all the ports.
     Please update below if you want to restrict access to certain ips and ports */
-    this.osSecurityGroup.addIngressRule(serverAccess, Port.allTcp());
+    this.osSecurityGroup.addIngressRule(serverAccess, Port.tcp(80));
+    this.osSecurityGroup.addIngressRule(serverAccess, Port.tcp(443));
+    this.osSecurityGroup.addIngressRule(serverAccess, Port.tcp(9200));
+    this.osSecurityGroup.addIngressRule(serverAccess, Port.tcp(5601));
+    this.osSecurityGroup.addIngressRule(serverAccess, Port.tcp(8443));
     this.osSecurityGroup.addIngressRule(this.osSecurityGroup, Port.allTraffic());
   }
 

--- a/test/opensearch-cluster-cdk.test.ts
+++ b/test/opensearch-cluster-cdk.test.ts
@@ -209,6 +209,38 @@ test('Test Resources with security enabled multi-node with existing Vpc with use
     SecurityGroupIngress: [
       {
         CidrIp: '10.10.10.10/32',
+        Description: 'from 10.10.10.10/32:80',
+        FromPort: 80,
+        IpProtocol: 'tcp',
+        ToPort: 80,
+      },
+      {
+        CidrIp: '10.10.10.10/32',
+        Description: 'from 10.10.10.10/32:443',
+        FromPort: 443,
+        IpProtocol: 'tcp',
+        ToPort: 443,
+      },
+      {
+        CidrIp: '10.10.10.10/32',
+        Description: 'from 10.10.10.10/32:9200',
+        FromPort: 9200,
+        IpProtocol: 'tcp',
+        ToPort: 9200,
+      },
+      {
+        CidrIp: '10.10.10.10/32',
+        Description: 'from 10.10.10.10/32:5601',
+        FromPort: 5601,
+        IpProtocol: 'tcp',
+        ToPort: 5601,
+      },
+      {
+        CidrIp: '10.10.10.10/32',
+        Description: 'from 10.10.10.10/32:8443',
+        FromPort: 8443,
+        IpProtocol: 'tcp',
+        ToPort: 8443,
       },
     ],
   });


### PR DESCRIPTION
### Description
In order to allow access only on specific ports of the cluster, this change modifies the tcp port access of security groups from alltcp to 80, 443, 9200, 5601 and 8443.

Since this is a breaking change, bumping the version to next major.

### Issues Resolved
related https://github.com/opensearch-project/opensearch-devops/issues/129

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
