### PR TITLE
Enforce TCP Protocol for target groups

### DIFF
--- a/lib/infra/infra-stack.ts
+++ b/lib/infra/infra-stack.ts
@@ -482,6 +482,7 @@ export class InfraStack extends Stack {
 
       opensearchListener.addTargets('single-node-target', {
         port: 9200,
+        protocol: Protocol.TCP,
         targets: [new InstanceTarget(singleNodeInstance)],
       });
 
@@ -489,6 +490,7 @@ export class InfraStack extends Stack {
         // @ts-ignore
         dashboardsListener.addTargets('single-node-osd-target', {
           port: 5601,
+          protocol: Protocol.TCP,
           targets: [new InstanceTarget(singleNodeInstance)],
         });
       }
@@ -662,6 +664,7 @@ export class InfraStack extends Stack {
 
       opensearchListener.addTargets('opensearchTarget', {
         port: 9200,
+        protocol: Protocol.TCP,
         targets: [clientNodeAsg],
       });
 
@@ -669,6 +672,7 @@ export class InfraStack extends Stack {
         // @ts-ignore
         dashboardsListener.addTargets('dashboardsTarget', {
           port: 5601,
+          protocol: Protocol.TCP,
           targets: [clientNodeAsg],
         });
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opensearch-project/opensearch-cluster-cdk",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@opensearch-project/opensearch-cluster-cdk",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.31.1",
         "@typescript-eslint/parser": "^4.31.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensearch-project/opensearch-cluster-cdk",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "bin": {
     "cdk_v2": "bin/app.js"
   },


### PR DESCRIPTION
### Description
Enforce TCP Protocol for target groups. By default, inherits the protocol of the listener in this case TLS when port is 443 and certificateArn is provided.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
