### PR TITLE
Make loadBalancer a readonly property

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opensearch-project/opensearch-cluster-cdk",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@opensearch-project/opensearch-cluster-cdk",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.31.1",
         "@typescript-eslint/parser": "^4.31.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensearch-project/opensearch-cluster-cdk",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "bin": {
     "cdk_v2": "bin/app.js"
   },


### PR DESCRIPTION
### Description
Like vpc and securityGroup, loadbalancer is also an essential property that might be used by downstream packages. Making it a public readonly property so that is accessible.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
