### PR TITLE
Add support for c5.2xlarge and c6g.2xlarge instance types

### DIFF
--- a/lib/opensearch-config/node-config.ts
+++ b/lib/opensearch-config/node-config.ts
@@ -43,6 +43,7 @@ export enum x64Ec2InstanceType {
   M5_2XLARGE = 'm5.2xlarge',
   C5_LARGE = 'c5.large',
   C5_XLARGE = 'c5.xlarge',
+  C5_2XLARGE = 'c5.2xlarge',
   R5_LARGE = 'r5.large',
   R5_XLARGE = 'r5.xlarge',
   R5_2XLARGE = 'r5.2xlarge',
@@ -64,6 +65,7 @@ export enum arm64Ec2InstanceType {
   M6G_2XLARGE = 'm6g.2xlarge',
   C6G_LARGE = 'c6g.large',
   C6G_XLARGE = 'c6g.xlarge',
+  C6G_2XLARGE = 'c6g.2xlarge',
   R6G_LARGE = 'r6g.large',
   R6G_XLARGE = 'r6g.xlarge',
   R6G_2XLARGE = 'r6g.2xlarge',
@@ -83,6 +85,8 @@ export const getX64InstanceTypes = (instanceType: string) => {
     return InstanceType.of(InstanceClass.C5, InstanceSize.LARGE);
   case x64Ec2InstanceType.C5_XLARGE:
     return InstanceType.of(InstanceClass.C5, InstanceSize.XLARGE);
+  case x64Ec2InstanceType.C5_2XLARGE:
+    return InstanceType.of(InstanceClass.C5, InstanceSize.XLARGE2);
   case x64Ec2InstanceType.R5_LARGE:
     return InstanceType.of(InstanceClass.R5, InstanceSize.LARGE);
   case x64Ec2InstanceType.R5_XLARGE:
@@ -126,6 +130,8 @@ export const getArm64InstanceTypes = (instanceType: string) => {
     return InstanceType.of(InstanceClass.C6G, InstanceSize.LARGE);
   case arm64Ec2InstanceType.C6G_XLARGE:
     return InstanceType.of(InstanceClass.C6G, InstanceSize.XLARGE);
+  case arm64Ec2InstanceType.C6G_2XLARGE:
+    return InstanceType.of(InstanceClass.C6G, InstanceSize.XLARGE2);
   case arm64Ec2InstanceType.R6G_LARGE:
     return InstanceType.of(InstanceClass.R6G, InstanceSize.LARGE);
   case arm64Ec2InstanceType.R6G_XLARGE:

--- a/test/opensearch-cluster-cdk.test.ts
+++ b/test/opensearch-cluster-cdk.test.ts
@@ -380,7 +380,7 @@ test('Throw error on wrong cpu arch to instance mapping', () => {
     expect(error).toBeInstanceOf(Error);
     // @ts-ignore
     expect(error.message).toEqual('Invalid instance type provided, please provide any one the following: '
-    + 'm6g.xlarge,m6g.2xlarge,c6g.large,c6g.xlarge,r6g.large,r6g.xlarge,r6g.2xlarge,r6g.4xlarge,r6g.8xlarge,'
+    + 'm6g.xlarge,m6g.2xlarge,c6g.large,c6g.xlarge,c6g.2xlarge,r6g.large,r6g.xlarge,r6g.2xlarge,r6g.4xlarge,r6g.8xlarge,'
     + 'g5g.large,g5g.xlarge');
   }
 });
@@ -422,7 +422,7 @@ test('Throw error on ec2 instance outside of enum list', () => {
     expect(error).toBeInstanceOf(Error);
     // @ts-ignore
     expect(error.message).toEqual('Invalid instance type provided, please provide any one the following: '
-    + 'm5.xlarge,m5.2xlarge,c5.large,c5.xlarge,r5.large,r5.xlarge,r5.2xlarge,r5.4xlarge,r5.8xlarge,g5.large,'
+    + 'm5.xlarge,m5.2xlarge,c5.large,c5.xlarge,c5.2xlarge,r5.large,r5.xlarge,r5.2xlarge,r5.4xlarge,r5.8xlarge,g5.large,'
     + 'g5.xlarge,i3.large,i3.xlarge,i3.2xlarge,i3.4xlarge,i3.8xlarge,inf1.xlarge,inf1.2xlarge');
   }
 });


### PR DESCRIPTION
### Description
Add support for c5.2xlarge and c6g.2xlarge instance types. 

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4754

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
