### PR TITLE
Fix cluster bootstrap when using a separate client node asg

### DIFF
--- a/lib/infra/infra-stack.ts
+++ b/lib/infra/infra-stack.ts
@@ -469,7 +469,7 @@ export class InfraStack extends Stack {
 
     let dashboardsListener: NetworkListener | ApplicationListener;
     if (this.dashboardsUrl !== 'undefined') {
-      const useSSLDashboardsListener = !this.securityDisabled && !this.minDistribution 
+      const useSSLDashboardsListener = !this.securityDisabled && !this.minDistribution
         && this.opensearchDashboardsPortMapping === 443 && certificateArn !== 'undefined';
       dashboardsListener = InfraStack.createListener(
         this.elb,
@@ -509,18 +509,18 @@ export class InfraStack extends Stack {
       // Disable target security for now, can be provided as an option in the future
       InfraStack.addTargetsToListener(
         opensearchListener,
-        this.elbType, 
-        'single-node-target', 
-        9200, 
+        this.elbType,
+        'single-node-target',
+        9200,
         new InstanceTarget(singleNodeInstance),
         false);
 
       if (this.dashboardsUrl !== 'undefined') {
         InfraStack.addTargetsToListener(
           dashboardsListener!,
-          this.elbType, 
-          'single-node-osd-target', 
-          5601, 
+          this.elbType,
+          'single-node-osd-target',
+          5601,
           new InstanceTarget(singleNodeInstance),
           false);
       }
@@ -652,7 +652,7 @@ export class InfraStack extends Stack {
           requireImdsv2: true,
           signals: Signals.waitForAll(),
         });
-        Tags.of(clientNodeAsg).add('cluster', scope.stackName);
+        Tags.of(clientNodeAsg).add('cluster', this.stackName);
       }
 
       Tags.of(clientNodeAsg).add('role', 'client');
@@ -690,18 +690,18 @@ export class InfraStack extends Stack {
       // Disable target security for now, can be provided as an option in the future
       InfraStack.addTargetsToListener(
         opensearchListener,
-        this.elbType, 
-        'opensearchTarget', 
-        9200, 
+        this.elbType,
+        'opensearchTarget',
+        9200,
         clientNodeAsg,
         false);
 
       if (this.dashboardsUrl !== 'undefined') {
         InfraStack.addTargetsToListener(
           dashboardsListener!,
-          this.elbType, 
-          'dashboardsTarget', 
-          5601, 
+          this.elbType,
+          'dashboardsTarget',
+          5601,
           clientNodeAsg,
           false);
       }


### PR DESCRIPTION
### Description
Currently an error is thrown that this tag must specify a value.

```
Error: Tag must have a value
    at new Tag (/Users/handalm/opensearch-cluster-cdk/node_modules/aws-cdk-lib/core/lib/tag-aspect.js:1:1498)
    at Tags.add (/Users/handalm/opensearch-cluster-cdk/node_modules/aws-cdk-lib/core/lib/tag-aspect.js:1:2705)
    at new InfraStack (/Users/handalm/opensearch-cluster-cdk/lib/infra/infra-stack.ts:655:32)
    at Object.<anonymous> (/Users/handalm/opensearch-cluster-cdk/bin/app.ts:46:20)
    at Module._compile (node:internal/modules/cjs/loader:1358:14)
    at Module.m._compile (/Users/handalm/opensearch-cluster-cdk/node_modules/ts-node/src/index.ts:1618:23)
    at Module._extensions..js (node:internal/modules/cjs/loader:1416:10)
    at Object.require.extensions.<computed> [as .ts] (/Users/handalm/opensearch-cluster-cdk/node_modules/ts-node/src/index.ts:1621:12)
    at Module.load (node:internal/modules/cjs/loader:1208:32)
    at Function.Module._load (node:internal/modules/cjs/loader:1024:12)
```

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
