### PR TITLE
Change default volume type to io1

### DIFF
--- a/lib/infra/infra-stack.ts
+++ b/lib/infra/infra-stack.ts
@@ -336,7 +336,7 @@ export class InfraStack extends Stack {
 
     const storageVolType = `${props?.storageVolumeType ?? scope.node.tryGetContext('storageVolumeType')}`;
     if (storageVolType === 'undefined') {
-      this.storageVolumeType = getVolumeType('gp3');
+      this.storageVolumeType = getVolumeType('io1');
     } else {
       this.storageVolumeType = getVolumeType(storageVolType);
     }
@@ -511,7 +511,11 @@ export class InfraStack extends Stack {
         securityGroup: props.securityGroup,
         blockDevices: [{
           deviceName: '/dev/xvda',
-          volume: BlockDeviceVolume.ebs(this.dataNodeStorage, { deleteOnTermination: true, volumeType: this.storageVolumeType }),
+          volume: BlockDeviceVolume.ebs(this.dataNodeStorage, {
+            deleteOnTermination: true,
+            volumeType: this.storageVolumeType,
+            iops: (this.storageVolumeType === EbsDeviceVolumeType.IO1) ? this.dataNodeStorage * 50 : 3000,
+          }),
         }],
         init: CloudFormationInit.fromElements(...this.getCfnInitElement(this, clusterLogGroup, 'single-node')),
         initOptions: {
@@ -564,7 +568,11 @@ export class InfraStack extends Stack {
             securityGroup: props.securityGroup,
             blockDevices: [{
               deviceName: '/dev/xvda',
-              volume: BlockDeviceVolume.ebs(50, { deleteOnTermination: true, volumeType: props.storageVolumeType }),
+              volume: BlockDeviceVolume.ebs(50, {
+                deleteOnTermination: true,
+                volumeType: this.storageVolumeType,
+                iops: (this.storageVolumeType === EbsDeviceVolumeType.IO1) ? 2500 : 3000,
+              }),
             }],
             requireImdsv2: true,
             userData: UserData.forLinux(),
@@ -600,7 +608,17 @@ export class InfraStack extends Stack {
           blockDevices: [{
             deviceName: '/dev/xvda',
             // eslint-disable-next-line max-len
-            volume: (seedConfig === 'seed-manager') ? BlockDeviceVolume.ebs(50, { deleteOnTermination: true, volumeType: props.storageVolumeType }) : BlockDeviceVolume.ebs(this.dataNodeStorage, { deleteOnTermination: true, volumeType: this.storageVolumeType }),
+            volume: (seedConfig === 'seed-manager') ? BlockDeviceVolume.ebs(50,
+              {
+                deleteOnTermination: true,
+                volumeType: this.storageVolumeType,
+                iops: (this.storageVolumeType === EbsDeviceVolumeType.IO1) ? 2500 : 3000,
+              })
+              : BlockDeviceVolume.ebs(this.dataNodeStorage, {
+                deleteOnTermination: true,
+                volumeType: this.storageVolumeType,
+                iops: (this.storageVolumeType === EbsDeviceVolumeType.IO1) ? this.dataNodeStorage * 50 : 3000,
+              }),
           }],
           requireImdsv2: true,
           userData: UserData.forLinux(),
@@ -630,7 +648,11 @@ export class InfraStack extends Stack {
           securityGroup: props.securityGroup,
           blockDevices: [{
             deviceName: '/dev/xvda',
-            volume: BlockDeviceVolume.ebs(this.dataNodeStorage, { deleteOnTermination: true, volumeType: this.storageVolumeType }),
+            volume: BlockDeviceVolume.ebs(this.dataNodeStorage, {
+              deleteOnTermination: true,
+              volumeType: this.storageVolumeType,
+              iops: (this.storageVolumeType === EbsDeviceVolumeType.IO1) ? this.dataNodeStorage * 50 : 3000,
+            }),
           }],
           requireImdsv2: true,
           userData: UserData.forLinux(),
@@ -663,7 +685,11 @@ export class InfraStack extends Stack {
             securityGroup: props.securityGroup,
             blockDevices: [{
               deviceName: '/dev/xvda',
-              volume: BlockDeviceVolume.ebs(50, { deleteOnTermination: true, volumeType: this.storageVolumeType }),
+              volume: BlockDeviceVolume.ebs(50, {
+                deleteOnTermination: true,
+                volumeType: this.storageVolumeType,
+                iops: (this.storageVolumeType === EbsDeviceVolumeType.IO1) ? 2500 : 3000,
+              }),
             }],
             requireImdsv2: true,
             userData: UserData.forLinux(),
@@ -697,7 +723,11 @@ export class InfraStack extends Stack {
             securityGroup: props.securityGroup,
             blockDevices: [{
               deviceName: '/dev/xvda',
-              volume: BlockDeviceVolume.ebs(this.mlNodeStorage, { deleteOnTermination: true, volumeType: this.storageVolumeType }),
+              volume: BlockDeviceVolume.ebs(this.mlNodeStorage, {
+                deleteOnTermination: true,
+                volumeType: this.storageVolumeType,
+                iops: (this.storageVolumeType === EbsDeviceVolumeType.IO1) ? this.mlNodeStorage * 50 : 3000,
+              }),
             }],
             requireImdsv2: true,
             userData: UserData.forLinux(),

--- a/lib/opensearch-config/node-config.ts
+++ b/lib/opensearch-config/node-config.ts
@@ -199,6 +199,8 @@ export const getVolumeType = (volumeType: string) => {
     return EbsDeviceVolumeType.GP2;
   case EbsDeviceVolumeType.GP3.valueOf():
     return EbsDeviceVolumeType.GP3;
+  case EbsDeviceVolumeType.IO1.valueOf():
+    return EbsDeviceVolumeType.IO1;
   default:
     throw new Error('Invalid volume type provided, please provide any one of the following: standard, gp2, gp3');
   }

--- a/test/opensearch-cluster-cdk.test.ts
+++ b/test/opensearch-cluster-cdk.test.ts
@@ -281,7 +281,8 @@ test('Test Resources with security enabled multi-node with existing Vpc with use
           DeviceName: '/dev/xvda',
           Ebs: {
             VolumeSize: 200,
-            VolumeType: 'gp3',
+            VolumeType: 'io1',
+            Iops: 10000,
           },
         },
       ],
@@ -674,7 +675,7 @@ test('Throw error on unsupported ebs volume type', () => {
       dataNodeStorage: 200,
       isInternal: true,
       dataInstanceType: 'r5.4xlarge',
-      storageVolumeType: 'io1',
+      storageVolumeType: 'io2',
     },
   });
   // WHEN


### PR DESCRIPTION
### Description
We recently updated default volume type to `gp3`. This caused regression in indexing latency for `vectorsearch` workload. 
Upon debugging we realized that this is happening due to reduced disk throughput on gp3. 
The default throughput for gp3 volume type is 125Mb/s, where as for gp2 it was 250Mb/s. 
Setting the `throughput` property in CDK code for gp3 volume didn't work as it is not currently supported out of the box, see https://github.com/aws/aws-cdk/issues/24107. They have provided a work around which is not a clean way. 

Given OpenSearch is an IOPS heavy application it makes more sense to use the best available EBS volume type to get maximum performance. `IO1` volume type requires `iops` property to be set and it is calculated based on disk size, `IOPS=50*Disk size in GB`.  See `io1` in https://aws.amazon.com/ebs/volume-types/. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
