### PR TITLE
Fix io1 iops to 5000

### DIFF
--- a/lib/infra/infra-stack.ts
+++ b/lib/infra/infra-stack.ts
@@ -514,7 +514,7 @@ export class InfraStack extends Stack {
           volume: BlockDeviceVolume.ebs(this.dataNodeStorage, {
             deleteOnTermination: true,
             volumeType: this.storageVolumeType,
-            iops: (this.storageVolumeType === EbsDeviceVolumeType.IO1) ? this.dataNodeStorage * 50 : 3000,
+            iops: (this.storageVolumeType === EbsDeviceVolumeType.IO1) ? 5000 : 3000,
           }),
         }],
         init: CloudFormationInit.fromElements(...this.getCfnInitElement(this, clusterLogGroup, 'single-node')),
@@ -617,7 +617,7 @@ export class InfraStack extends Stack {
               : BlockDeviceVolume.ebs(this.dataNodeStorage, {
                 deleteOnTermination: true,
                 volumeType: this.storageVolumeType,
-                iops: (this.storageVolumeType === EbsDeviceVolumeType.IO1) ? this.dataNodeStorage * 50 : 3000,
+                iops: (this.storageVolumeType === EbsDeviceVolumeType.IO1) ? 5000 : 3000,
               }),
           }],
           requireImdsv2: true,
@@ -651,7 +651,7 @@ export class InfraStack extends Stack {
             volume: BlockDeviceVolume.ebs(this.dataNodeStorage, {
               deleteOnTermination: true,
               volumeType: this.storageVolumeType,
-              iops: (this.storageVolumeType === EbsDeviceVolumeType.IO1) ? this.dataNodeStorage * 50 : 3000,
+              iops: (this.storageVolumeType === EbsDeviceVolumeType.IO1) ? 5000 : 3000,
             }),
           }],
           requireImdsv2: true,
@@ -726,7 +726,7 @@ export class InfraStack extends Stack {
               volume: BlockDeviceVolume.ebs(this.mlNodeStorage, {
                 deleteOnTermination: true,
                 volumeType: this.storageVolumeType,
-                iops: (this.storageVolumeType === EbsDeviceVolumeType.IO1) ? this.mlNodeStorage * 50 : 3000,
+                iops: (this.storageVolumeType === EbsDeviceVolumeType.IO1) ? 5000 : 3000,
               }),
             }],
             requireImdsv2: true,

--- a/test/opensearch-cluster-cdk.test.ts
+++ b/test/opensearch-cluster-cdk.test.ts
@@ -282,7 +282,7 @@ test('Test Resources with security enabled multi-node with existing Vpc with use
           Ebs: {
             VolumeSize: 200,
             VolumeType: 'io1',
-            Iops: 10000,
+            Iops: 5000,
           },
         },
       ],


### PR DESCRIPTION
### Description
Fixing io1 IOPS to 5000 as setting it to 50*(volume size in GB) will also give a max to 500Mbps throughput. 
This is also causing IOPS limit issue in AWS account. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
