### PR TITLE
Change the ec2 instance ami to AL2

### DIFF
--- a/lib/infra/infra-stack.ts
+++ b/lib/infra/infra-stack.ts
@@ -499,7 +499,7 @@ export class InfraStack extends Stack {
       singleNodeInstance = new Instance(this, 'single-node-instance', {
         vpc: props.vpc,
         instanceType: singleNodeInstanceType,
-        machineImage: MachineImage.latestAmazonLinux2023(
+        machineImage: MachineImage.latestAmazonLinux2(
           {
             cpuType: instanceCpuType,
           },
@@ -561,7 +561,7 @@ export class InfraStack extends Stack {
         const managerNodeAsg = new AutoScalingGroup(this, 'managerNodeAsg', {
           launchTemplate: new LaunchTemplate(this, 'managerNodeLt', {
             instanceType: defaultInstanceType,
-            machineImage: MachineImage.latestAmazonLinux2023({
+            machineImage: MachineImage.latestAmazonLinux2({
               cpuType: instanceCpuType,
             }),
             role: this.instanceRole,
@@ -600,7 +600,7 @@ export class InfraStack extends Stack {
       const seedNodeAsg = new AutoScalingGroup(this, 'seedNodeAsg', {
         launchTemplate: new LaunchTemplate(this, 'seedNodeLt', {
           instanceType: (seedConfig === 'seed-manager') ? defaultInstanceType : this.dataInstanceType,
-          machineImage: MachineImage.latestAmazonLinux2023({
+          machineImage: MachineImage.latestAmazonLinux2({
             cpuType: instanceCpuType,
           }),
           role: this.instanceRole,
@@ -641,7 +641,7 @@ export class InfraStack extends Stack {
       const dataNodeAsg = new AutoScalingGroup(this, 'dataNodeAsg', {
         launchTemplate: new LaunchTemplate(this, 'dataNodeLt', {
           instanceType: this.dataInstanceType,
-          machineImage: MachineImage.latestAmazonLinux2023({
+          machineImage: MachineImage.latestAmazonLinux2({
             cpuType: instanceCpuType,
           }),
           role: this.instanceRole,
@@ -678,7 +678,7 @@ export class InfraStack extends Stack {
         clientNodeAsg = new AutoScalingGroup(this, 'clientNodeAsg', {
           launchTemplate: new LaunchTemplate(this, 'clientNodelt', {
             instanceType: defaultInstanceType,
-            machineImage: MachineImage.latestAmazonLinux2023({
+            machineImage: MachineImage.latestAmazonLinux2({
               cpuType: instanceCpuType,
             }),
             role: this.instanceRole,
@@ -716,7 +716,7 @@ export class InfraStack extends Stack {
         const mlNodeAsg = new AutoScalingGroup(this, 'mlNodeAsg', {
           launchTemplate: new LaunchTemplate(this, 'mlNodeLt', {
             instanceType: this.mlInstanceType,
-            machineImage: MachineImage.latestAmazonLinux2023({
+            machineImage: MachineImage.latestAmazonLinux2({
               cpuType: instanceCpuType,
             }),
             role: this.instanceRole,

--- a/test/infra-stack-props.test.ts
+++ b/test/infra-stack-props.test.ts
@@ -44,8 +44,7 @@ test('Throw error on incorrect JSON for opensearch', () => {
   } catch (error) {
     expect(error).toBeInstanceOf(Error);
     // @ts-ignore
-    expect(error.message).toEqual('Encountered following error while parsing additionalConfig json parameter: '
-      + 'SyntaxError: Unexpected token e in JSON at position 33');
+    expect(error.message).toContain('Encountered following error while parsing additionalConfig json parameter:');
   }
 });
 
@@ -84,8 +83,7 @@ test('Throw error on incorrect JSON for opensearch-dashboards', () => {
   } catch (error) {
     expect(error).toBeInstanceOf(Error);
     // @ts-ignore
-    expect(error.message).toEqual('Encountered following error while parsing additionalOsdConfig json parameter: '
-      + 'SyntaxError: Unexpected token s in JSON at position 31');
+    expect(error.message).toContain('Encountered following error while parsing additionalOsdConfig json parameter:');
   }
 });
 

--- a/test/opensearch-cluster-cdk.test.ts
+++ b/test/opensearch-cluster-cdk.test.ts
@@ -777,8 +777,7 @@ test('Throw error on incorrect JSON', () => {
   } catch (error) {
     expect(error).toBeInstanceOf(Error);
     // @ts-ignore
-    expect(error.message).toEqual('Encountered following error while parsing customConfigFiles json parameter: '
-    + 'SyntaxError: Unexpected token o in JSON at position 25');
+    expect(error.message).toContain('Encountered following error while parsing customConfigFiles json parameter:');
   }
 });
 


### PR DESCRIPTION
### Description
We recently started seeing r[egression ](https://s12d.com/P4j-NnhI)in our nightly benchmarks across all tracking OS versions, even for 2.17 which is GA since Sept-12.
So it couldn't be something changed on the OpenSearch side, since we use snapshot for data restore, it could not be corpus or index mapping getting changed, and I have OSB version also pinned to 1.8.0 for a few months, so it couldn't be something changed on OSB side.
After digging further I looked into underlying OS, which is AL2023 and it recently had new ami released (Oct-10).
I was looking at change logs but nothing jumped out of the ordinary. Just a few hours ago another user reported latency regression after switching to Al2023 and the root cause seems to be the OpenSSL library version. See https://github.com/amazonlinux/amazon-linux-2023/issues/819 After going into the rabbit hole i found some other issues as well.
https://github.com/aws/aws-lambda-base-images/issues/154
https://github.com/openssl/openssl/issues/17064

This PR updates the ec2 instance ami to us AL2. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
