### PR TITLE
bug-fix: r5.2xlarge was creating r5.xlarge instances

### DIFF
--- a/lib/opensearch-config/node-config.ts
+++ b/lib/opensearch-config/node-config.ts
@@ -118,7 +118,7 @@ export const getX64InstanceTypes = (instanceType: string): InstanceTypeInfo => {
   case x64Ec2InstanceType.R5_XLARGE:
     return { instance: InstanceType.of(InstanceClass.R5, InstanceSize.XLARGE), hasInternalStorage: false };
   case x64Ec2InstanceType.R5_2XLARGE:
-    return { instance: InstanceType.of(InstanceClass.R5, InstanceSize.XLARGE), hasInternalStorage: false };
+    return { instance: InstanceType.of(InstanceClass.R5, InstanceSize.XLARGE2), hasInternalStorage: false };
   case x64Ec2InstanceType.R5_4XLARGE:
     return { instance: InstanceType.of(InstanceClass.R5, InstanceSize.XLARGE4), hasInternalStorage: false };
   case x64Ec2InstanceType.R5_8XLARGE:


### PR DESCRIPTION
### Description
bug-fix: r5.2xlarge was creating r5.xlarge instances. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
