### PR TITLE
Adding S3 Distribution URL Support

### DIFF
--- a/lib/infra/infra-stack.ts
+++ b/lib/infra/infra-stack.ts
@@ -388,9 +388,12 @@ export class InfraStack extends Stack {
     this.customRoleArn = `${props?.customRoleArn ?? scope.node.tryGetContext('customRoleArn')}`;
     if (this.customRoleArn === 'undefined') {
       this.instanceRole = new Role(this, 'instanceRole', {
-        managedPolicies: [ManagedPolicy.fromAwsManagedPolicyName('AmazonEC2ReadOnlyAccess'),
+        managedPolicies: [
+          ManagedPolicy.fromAwsManagedPolicyName('AmazonEC2ReadOnlyAccess'),
           ManagedPolicy.fromAwsManagedPolicyName('CloudWatchAgentServerPolicy'),
-          ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore')],
+          ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore'),
+          ManagedPolicy.fromAwsManagedPolicyName('AmazonS3ReadOnlyAccess')
+        ],
         assumedBy: new ServicePrincipal('ec2.amazonaws.com'),
       });
     } else {
@@ -899,8 +902,13 @@ export class InfraStack extends Stack {
       // eslint-disable-next-line max-len
       InitCommand.shellCommand('set -ex;/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s'),
       InitCommand.shellCommand('set -ex; sudo echo "vm.max_map_count=262144" >> /etc/sysctl.conf;sudo sysctl -p'),
-      InitCommand.shellCommand(`set -ex;mkdir opensearch; curl -L ${this.distributionUrl} -o opensearch.tar.gz;`
-          + 'tar zxf opensearch.tar.gz -C opensearch --strip-components=1; chown -R ec2-user:ec2-user opensearch;', {
+      InitCommand.shellCommand(`set -ex;mkdir opensearch; 
+        if [[ "${this.distributionUrl}" == s3://* ]]; then 
+          aws s3 cp "${this.distributionUrl}" opensearch.tar.gz; 
+        else 
+          curl -L "${this.distributionUrl}" -o opensearch.tar.gz; 
+        fi;
+        tar zxf opensearch.tar.gz -C opensearch --strip-components=1; chown -R ec2-user:ec2-user opensearch;`, {
         cwd: currentWorkDir,
         ignoreErrors: false,
       }),
@@ -1081,8 +1089,13 @@ export class InfraStack extends Stack {
 
     // If OpenSearch-Dashboards URL is present
     if (this.dashboardsUrl !== 'undefined') {
-      cfnInitConfig.push(InitCommand.shellCommand(`set -ex;mkdir opensearch-dashboards; curl -L ${this.dashboardsUrl} -o opensearch-dashboards.tar.gz;`
-          + 'tar zxf opensearch-dashboards.tar.gz -C opensearch-dashboards --strip-components=1; chown -R ec2-user:ec2-user opensearch-dashboards;', {
+      cfnInitConfig.push(InitCommand.shellCommand(`set -ex;mkdir opensearch-dashboards; 
+        if [[ "${this.dashboardsUrl}" == s3://* ]]; then 
+          aws s3 cp "${this.dashboardsUrl}" opensearch-dashboards.tar.gz; 
+        else 
+          curl -L "${this.dashboardsUrl}" -o opensearch-dashboards.tar.gz; 
+        fi;
+        tar zxf opensearch-dashboards.tar.gz -C opensearch-dashboards --strip-components=1; chown -R ec2-user:ec2-user opensearch-dashboards;`, {
         cwd: currentWorkDir,
         ignoreErrors: false,
       }));


### PR DESCRIPTION
### Description
This adds functionality to take in a S3 URI and use it as a distribution URL for deploying an Opensearch cluster.

### Issues Resolved
#149 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
