### PR TITLE
Add support for t3.medium instance type

### DIFF
--- a/lib/opensearch-config/node-config.ts
+++ b/lib/opensearch-config/node-config.ts
@@ -63,7 +63,8 @@ export enum x64Ec2InstanceType {
   I3_4XLARGE = 'i3.4xlarge',
   I3_8XLARGE = 'i3.8xlarge',
   INF1_XLARGE = 'inf1.xlarge',
-  INF1_2XLARGE = 'inf1.2xlarge'
+  INF1_2XLARGE = 'inf1.2xlarge',
+  T3_MEDIUM = 't3.medium'
 }
 
 export enum arm64Ec2InstanceType {
@@ -149,6 +150,8 @@ export const getX64InstanceTypes = (instanceType: string): InstanceTypeInfo => {
     return { instance: InstanceType.of(InstanceClass.INF1, InstanceSize.XLARGE), hasInternalStorage: false };
   case x64Ec2InstanceType.INF1_2XLARGE:
     return { instance: InstanceType.of(InstanceClass.INF1, InstanceSize.XLARGE2), hasInternalStorage: false };
+  case x64Ec2InstanceType.T3_MEDIUM:
+    return { instance: InstanceType.of(InstanceClass.T3, InstanceSize.MEDIUM), hasInternalStorage: false };
   default:
     throw new Error(`Invalid instance type provided, please provide any one the following: ${Object.values(x64Ec2InstanceType)}`);
   }

--- a/test/opensearch-cluster-cdk.test.ts
+++ b/test/opensearch-cluster-cdk.test.ts
@@ -440,7 +440,7 @@ test('Throw error on ec2 instance outside of enum list', () => {
     // @ts-ignore
     expect(error.message).toEqual('Invalid instance type provided, please provide any one the following: m5.xlarge,m5.2xlarge,c5.large,c5.xlarge,'
       + 'c5.2xlarge,c5d.xlarge,c5d.2xlarge,r5.large,r5.xlarge,r5.2xlarge,r5.4xlarge,r5.8xlarge,r5d.xlarge,r5d.2xlarge,r5d.4xlarge,r5d.8xlarge,'
-      + 'g5.large,g5.xlarge,i3.large,i3.xlarge,i3.2xlarge,i3.4xlarge,i3.8xlarge,inf1.xlarge,inf1.2xlarge');
+      + 'g5.large,g5.xlarge,i3.large,i3.xlarge,i3.2xlarge,i3.4xlarge,i3.8xlarge,inf1.xlarge,inf1.2xlarge,t3.medium');
   }
 });
 


### PR DESCRIPTION
### Description
Add support for t3.medium instance type. 
Also adds logic to enable 2G swap if t3.medium instance type is selected. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
