### PR TITLE
Disbaled R8 type instances

### DIFF
--- a/lib/opensearch-config/node-config.ts
+++ b/lib/opensearch-config/node-config.ts
@@ -99,14 +99,15 @@ export enum arm64Ec2InstanceType {
   R7GD_2XLARGE = 'r7gd.2xlarge',
   R7GD_4XLARGE = 'r7gd.4xlarge',
   R7GD_8XLARGE = 'r7gd.8xlarge',
-  R8G_XLARGE = 'r8g.xlarge',
-  R8G_2XLARGE = 'r8g.2xlarge',
-  R8G_4XLARGE = 'r8g.4xlarge',
-  R8G_8XLARGE = 'r8g.8xlarge',
-  R8GD_XLARGE = 'r8gd.xlarge',
-  R8GD_2XLARGE = 'r8gd.2xlarge',
-  R8GD_4XLARGE = 'r8gd.4xlarge',
-  R8GD_8XLARGE = 'r8gd.8xlarge',
+// Disabling temporarily till we upgrade the nightly benchmarks ami to use Node 20, it currently has node 18 which doesn't support below instance types in the aws-cdk-lib version 2.248.0
+ // R8G_XLARGE = 'r8g.xlarge',
+ // R8G_2XLARGE = 'r8g.2xlarge',
+ // R8G_4XLARGE = 'r8g.4xlarge',
+ // R8G_8XLARGE = 'r8g.8xlarge',
+ // R8GD_XLARGE = 'r8gd.xlarge',
+ // R8GD_2XLARGE = 'r8gd.2xlarge',
+ // R8GD_4XLARGE = 'r8gd.4xlarge',
+ // R8GD_8XLARGE = 'r8gd.8xlarge',
   G5G_LARGE = 'g5g.large',
   G5G_XLARGE = 'g5g.xlarge'
 }
@@ -238,22 +239,22 @@ export const getArm64InstanceTypes = (instanceType: string): InstanceTypeInfo =>
     return { instance: InstanceType.of(InstanceClass.R7GD, InstanceSize.XLARGE4), hasInternalStorage: true };
   case arm64Ec2InstanceType.R7GD_8XLARGE:
     return { instance: InstanceType.of(InstanceClass.R7GD, InstanceSize.XLARGE8), hasInternalStorage: true };
-  case arm64Ec2InstanceType.R8G_XLARGE:
-    return { instance: InstanceType.of(InstanceClass.R8G, InstanceSize.XLARGE), hasInternalStorage: false };
-  case arm64Ec2InstanceType.R8G_2XLARGE:
-    return { instance: InstanceType.of(InstanceClass.R8G, InstanceSize.XLARGE2), hasInternalStorage: false };
-  case arm64Ec2InstanceType.R8G_4XLARGE:
-    return { instance: InstanceType.of(InstanceClass.R8G, InstanceSize.XLARGE4), hasInternalStorage: false };
-  case arm64Ec2InstanceType.R8G_8XLARGE:
-    return { instance: InstanceType.of(InstanceClass.R8G, InstanceSize.XLARGE8), hasInternalStorage: false };
-  case arm64Ec2InstanceType.R8GD_XLARGE:
-    return { instance: InstanceType.of(InstanceClass.R8GD, InstanceSize.XLARGE), hasInternalStorage: true };
-  case arm64Ec2InstanceType.R8GD_2XLARGE:
-    return { instance: InstanceType.of(InstanceClass.R8GD, InstanceSize.XLARGE2), hasInternalStorage: true };
-  case arm64Ec2InstanceType.R8GD_4XLARGE:
-    return { instance: InstanceType.of(InstanceClass.R8GD, InstanceSize.XLARGE4), hasInternalStorage: true };
-  case arm64Ec2InstanceType.R8GD_8XLARGE:
-    return { instance: InstanceType.of(InstanceClass.R8GD, InstanceSize.XLARGE8), hasInternalStorage: true };
+  // case arm64Ec2InstanceType.R8G_XLARGE:
+  //  return { instance: InstanceType.of(InstanceClass.R8G, InstanceSize.XLARGE), hasInternalStorage: false };
+  // case arm64Ec2InstanceType.R8G_2XLARGE:
+  //  return { instance: InstanceType.of(InstanceClass.R8G, InstanceSize.XLARGE2), hasInternalStorage: false };
+  // case arm64Ec2InstanceType.R8G_4XLARGE:
+  //  return { instance: InstanceType.of(InstanceClass.R8G, InstanceSize.XLARGE4), hasInternalStorage: false };
+  // case arm64Ec2InstanceType.R8G_8XLARGE:
+  //  return { instance: InstanceType.of(InstanceClass.R8G, InstanceSize.XLARGE8), hasInternalStorage: false };
+  // case arm64Ec2InstanceType.R8GD_XLARGE:
+  //  return { instance: InstanceType.of(InstanceClass.R8GD, InstanceSize.XLARGE), hasInternalStorage: true };
+  // case arm64Ec2InstanceType.R8GD_2XLARGE:
+  //  return { instance: InstanceType.of(InstanceClass.R8GD, InstanceSize.XLARGE2), hasInternalStorage: true };
+  // case arm64Ec2InstanceType.R8GD_4XLARGE:
+  //  return { instance: InstanceType.of(InstanceClass.R8GD, InstanceSize.XLARGE4), hasInternalStorage: true };
+  // case arm64Ec2InstanceType.R8GD_8XLARGE:
+  //  return { instance: InstanceType.of(InstanceClass.R8GD, InstanceSize.XLARGE8), hasInternalStorage: true };
   case arm64Ec2InstanceType.G5G_LARGE:
     return { instance: InstanceType.of(InstanceClass.G5G, InstanceSize.LARGE), hasInternalStorage: true };
   case arm64Ec2InstanceType.G5G_XLARGE:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.31.1",
         "@typescript-eslint/parser": "^4.31.1",
-        "aws-cdk-lib": "2.248.0",
+        "aws-cdk-lib": "2.177.0",
         "constructs": "^10.0.0",
         "eslint": "^7.32.0",
         "eslint-config-airbnb-base": "^14.2.1",
@@ -41,6 +41,12 @@
       "integrity": "sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==",
       "license": "Apache-2.0"
     },
+    "node_modules/@aws-cdk/asset-kubectl-v20": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.4.tgz",
+      "integrity": "sha512-Ps2MkmjYgMyflagqQ4dgTElc7Vwpqj8spw8dQVFiSeaaMPsuDSNsPax3/HjuDuwqsmLdaCZc6umlxYLpL0kYDA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.1.tgz",
@@ -48,9 +54,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "53.14.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.14.0.tgz",
-      "integrity": "sha512-prx2sbFfKrVf3NNXMOmWq6lsIBeWQDIqMTILLAddGiidn9j7OnLUubknWpJlLozMveTvQELdI++nUwq6jwCm9g==",
+      "version": "39.2.20",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-39.2.20.tgz",
+      "integrity": "sha512-RI7S8jphGA8mak154ElnEJQPNTTV4PZmA7jgqnBBHQGyOPJIXxtACubNQ5m4YgjpkK3UJHsWT+/cOAfM/Au/Wg==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -58,10 +64,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
+        "semver": "^7.7.1"
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
@@ -73,7 +76,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.7.1",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -1865,12 +1868,11 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.248.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.248.0.tgz",
-      "integrity": "sha512-PGQycx/OdyX+t0o6QUFI1KJAOLoyIVj2WwrN0syrwCi8lYxW2KzldZsW0X+/UN/ALNQwcjSr927ImTpuDOh+bg==",
+      "version": "2.177.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.177.0.tgz",
+      "integrity": "sha512-nTnHAwjZaPJ5gfJjtzE/MyK6q0a66nWthoJl7l8srucRb+I30dczhbbXor6QCdVpJaTRAEliMOMq23aglsAQbg==",
       "bundleDependencies": [
         "@balena/dockerignore",
-        "@aws-cdk/cloud-assembly-api",
         "case",
         "fs-extra",
         "ignore",
@@ -1884,65 +1886,27 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "2.2.273",
-        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.2.0",
-        "@aws-cdk/cloud-assembly-schema": "^53.0.0",
+        "@aws-cdk/asset-awscli-v1": "^2.2.208",
+        "@aws-cdk/asset-kubectl-v20": "^2.1.3",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
+        "@aws-cdk/cloud-assembly-schema": "^39.2.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.3.3",
+        "fs-extra": "^11.2.0",
         "ignore": "^5.3.2",
-        "jsonschema": "^1.5.0",
+        "jsonschema": "^1.4.1",
         "mime-types": "^2.1.35",
-        "minimatch": "^10.2.3",
+        "minimatch": "^3.1.2",
         "punycode": "^2.3.1",
-        "semver": "^7.7.4",
-        "table": "^6.9.0",
-        "yaml": "1.10.3"
+        "semver": "^7.6.3",
+        "table": "^6.8.2",
+        "yaml": "1.10.2"
       },
       "engines": {
-        "node": ">= 20.0.0"
+        "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "constructs": "^10.5.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.0",
-      "bundleDependencies": [
-        "jsonschema",
-        "semver"
-      ],
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.0.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
-      "version": "7.7.4",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "constructs": "^10.0.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
@@ -1951,7 +1915,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/aws-cdk-lib/node_modules/ajv": {
-      "version": "8.18.0",
+      "version": "8.17.1",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1996,22 +1960,17 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/balanced-match": {
-      "version": "4.0.4",
+      "version": "1.0.2",
       "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
+      "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.5",
+      "version": "1.1.11",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/case": {
@@ -2038,6 +1997,11 @@
       "inBundle": true,
       "license": "MIT"
     },
+    "node_modules/aws-cdk-lib/node_modules/concat-map": {
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
       "version": "8.0.0",
       "inBundle": true,
@@ -2049,22 +2013,12 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-uri": {
-      "version": "3.1.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
+      "version": "3.0.3",
       "inBundle": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.3.3",
+      "version": "11.2.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2103,7 +2057,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
-      "version": "6.2.0",
+      "version": "6.1.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2114,7 +2068,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/jsonschema": {
-      "version": "1.5.0",
+      "version": "1.4.1",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2146,17 +2100,14 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/minimatch": {
-      "version": "10.2.5",
+      "version": "3.1.2",
       "inBundle": true,
-      "license": "BlueOak-1.0.0",
+      "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^1.1.7"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": "*"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/punycode": {
@@ -2176,7 +2127,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.6.3",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -2227,7 +2178,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/table": {
-      "version": "6.9.0",
+      "version": "6.8.2",
       "inBundle": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2250,7 +2201,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/yaml": {
-      "version": "1.10.3",
+      "version": "1.10.2",
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -6855,18 +6806,23 @@
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.273.tgz",
       "integrity": "sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg=="
     },
+    "@aws-cdk/asset-kubectl-v20": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.4.tgz",
+      "integrity": "sha512-Ps2MkmjYgMyflagqQ4dgTElc7Vwpqj8spw8dQVFiSeaaMPsuDSNsPax3/HjuDuwqsmLdaCZc6umlxYLpL0kYDA=="
+    },
     "@aws-cdk/asset-node-proxy-agent-v6": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.1.tgz",
       "integrity": "sha512-We4bmHaowOPHr+IQR4/FyTGjRfjgBj4ICMjtqmJeBDWad3Q/6St12NT07leNtyuukv2qMhtSZJQorD8KpKTwRA=="
     },
     "@aws-cdk/cloud-assembly-schema": {
-      "version": "53.14.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.14.0.tgz",
-      "integrity": "sha512-prx2sbFfKrVf3NNXMOmWq6lsIBeWQDIqMTILLAddGiidn9j7OnLUubknWpJlLozMveTvQELdI++nUwq6jwCm9g==",
+      "version": "39.2.20",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-39.2.20.tgz",
+      "integrity": "sha512-RI7S8jphGA8mak154ElnEJQPNTTV4PZmA7jgqnBBHQGyOPJIXxtACubNQ5m4YgjpkK3UJHsWT+/cOAfM/Au/Wg==",
       "requires": {
         "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
+        "semver": "^7.7.1"
       },
       "dependencies": {
         "jsonschema": {
@@ -6874,7 +6830,7 @@
           "bundled": true
         },
         "semver": {
-          "version": "7.7.4",
+          "version": "7.7.1",
           "bundled": true
         }
       }
@@ -8174,51 +8130,33 @@
       }
     },
     "aws-cdk-lib": {
-      "version": "2.248.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.248.0.tgz",
-      "integrity": "sha512-PGQycx/OdyX+t0o6QUFI1KJAOLoyIVj2WwrN0syrwCi8lYxW2KzldZsW0X+/UN/ALNQwcjSr927ImTpuDOh+bg==",
+      "version": "2.177.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.177.0.tgz",
+      "integrity": "sha512-nTnHAwjZaPJ5gfJjtzE/MyK6q0a66nWthoJl7l8srucRb+I30dczhbbXor6QCdVpJaTRAEliMOMq23aglsAQbg==",
       "requires": {
-        "@aws-cdk/asset-awscli-v1": "2.2.273",
-        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.2.0",
-        "@aws-cdk/cloud-assembly-schema": "^53.0.0",
+        "@aws-cdk/asset-awscli-v1": "^2.2.208",
+        "@aws-cdk/asset-kubectl-v20": "^2.1.3",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
+        "@aws-cdk/cloud-assembly-schema": "^39.2.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.3.3",
+        "fs-extra": "^11.2.0",
         "ignore": "^5.3.2",
-        "jsonschema": "^1.5.0",
+        "jsonschema": "^1.4.1",
         "mime-types": "^2.1.35",
-        "minimatch": "^10.2.3",
+        "minimatch": "^3.1.2",
         "punycode": "^2.3.1",
-        "semver": "^7.7.4",
-        "table": "^6.9.0",
-        "yaml": "1.10.3"
+        "semver": "^7.6.3",
+        "table": "^6.8.2",
+        "yaml": "1.10.2"
       },
       "dependencies": {
-        "@aws-cdk/cloud-assembly-api": {
-          "version": "2.2.0",
-          "bundled": true,
-          "requires": {
-            "jsonschema": "~1.4.1",
-            "semver": "^7.7.4"
-          },
-          "dependencies": {
-            "jsonschema": {
-              "version": "1.4.1",
-              "bundled": true
-            },
-            "semver": {
-              "version": "7.7.4",
-              "bundled": true
-            }
-          }
-        },
         "@balena/dockerignore": {
           "version": "1.0.2",
           "bundled": true
         },
         "ajv": {
-          "version": "8.18.0",
+          "version": "8.17.1",
           "bundled": true,
           "requires": {
             "fast-deep-equal": "^3.1.3",
@@ -8243,14 +8181,15 @@
           "bundled": true
         },
         "balanced-match": {
-          "version": "4.0.4",
+          "version": "1.0.2",
           "bundled": true
         },
         "brace-expansion": {
-          "version": "5.0.5",
+          "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "balanced-match": "^4.0.2"
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
           }
         },
         "case": {
@@ -8268,6 +8207,10 @@
           "version": "1.1.4",
           "bundled": true
         },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
         "emoji-regex": {
           "version": "8.0.0",
           "bundled": true
@@ -8277,11 +8220,11 @@
           "bundled": true
         },
         "fast-uri": {
-          "version": "3.1.0",
+          "version": "3.0.3",
           "bundled": true
         },
         "fs-extra": {
-          "version": "11.3.3",
+          "version": "11.2.0",
           "bundled": true,
           "requires": {
             "graceful-fs": "^4.2.0",
@@ -8306,7 +8249,7 @@
           "bundled": true
         },
         "jsonfile": {
-          "version": "6.2.0",
+          "version": "6.1.0",
           "bundled": true,
           "requires": {
             "graceful-fs": "^4.1.6",
@@ -8314,7 +8257,7 @@
           }
         },
         "jsonschema": {
-          "version": "1.5.0",
+          "version": "1.4.1",
           "bundled": true
         },
         "lodash.truncate": {
@@ -8333,10 +8276,10 @@
           }
         },
         "minimatch": {
-          "version": "10.2.5",
+          "version": "3.1.2",
           "bundled": true,
           "requires": {
-            "brace-expansion": "^5.0.5"
+            "brace-expansion": "^1.1.7"
           }
         },
         "punycode": {
@@ -8348,7 +8291,7 @@
           "bundled": true
         },
         "semver": {
-          "version": "7.7.4",
+          "version": "7.6.3",
           "bundled": true
         },
         "slice-ansi": {
@@ -8377,7 +8320,7 @@
           }
         },
         "table": {
-          "version": "6.9.0",
+          "version": "6.8.2",
           "bundled": true,
           "requires": {
             "ajv": "^8.0.1",
@@ -8392,7 +8335,7 @@
           "bundled": true
         },
         "yaml": {
-          "version": "1.10.3",
+          "version": "1.10.2",
           "bundled": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^4.31.1",
     "@typescript-eslint/parser": "^4.31.1",
-    "aws-cdk-lib": "2.248.0",
+    "aws-cdk-lib": "2.177.0",
     "constructs": "^10.0.0",
     "eslint": "^7.32.0",
     "eslint-config-airbnb-base": "^14.2.1",


### PR DESCRIPTION
### Description
Disabling R8 type instances temporarily till we upgrade the node version on nightly benchmark platform to node 20 as it is currently breaking. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
