### PR TITLE
Change to accomodate suffix added to opnsearch-tar-install.sh script

### DIFF
--- a/lib/infra/infra-stack.ts
+++ b/lib/infra/infra-stack.ts
@@ -1209,7 +1209,8 @@ export class InfraStack extends Stack {
         }));
     } else {
       cfnInitConfig.push(InitCommand.shellCommand('set -ex;cd opensearch; '
-        + `sudo -u ec2-user nohup env OPENSEARCH_INITIAL_ADMIN_PASSWORD=${this.adminPassword} ./opensearch-tar-install.sh >> install.log 2>&1 &`,
+        // eslint-disable-next-line max-len
+        + `INSTALL_SCRIPT=$(ls opensearch-tar-install*.sh); sudo -u ec2-user nohup env OPENSEARCH_INITIAL_ADMIN_PASSWORD=${this.adminPassword} ./$INSTALL_SCRIPT >> install.log 2>&1 &`,
       {
         cwd: currentWorkDir,
         ignoreErrors: false,


### PR DESCRIPTION
### Description
Change to accomodate suffix added to opnsearch-tar-install.sh script. 
The datafusion tarball startup script has datafusion suffix in  opnsearch-tar-install.sh, `opnsearch-tar-install-datafusion.sh`.
This change adds a check to fetch what is the startup script name and then executes it. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
