### PR TITLE
Parameterize VPC with maxAzs and natGateways context vars

### DIFF
--- a/lib/infra/infra-stack.ts
+++ b/lib/infra/infra-stack.ts
@@ -308,6 +308,9 @@ export class InfraStack extends Stack {
     const singleNodeCluster = `${props?.singleNodeCluster ?? scope.node.tryGetContext('singleNodeCluster')}`;
     this.singleNodeCluster = singleNodeCluster === 'true';
 
+    const natGatewaysCtx = `${scope.node.tryGetContext('natGateways')}`;
+    const usePublicSubnet = natGatewaysCtx === '0';
+
     const managerCount = `${props?.managerNodeCount ?? scope.node.tryGetContext('managerNodeCount')}`;
     if (managerCount === 'undefined') {
       this.managerNodeCount = 3;
@@ -576,8 +579,9 @@ export class InfraStack extends Stack {
         ),
         role: this.instanceRole,
         vpcSubnets: {
-          subnetType: SubnetType.PRIVATE_WITH_EGRESS,
+          subnetType: usePublicSubnet ? SubnetType.PUBLIC : SubnetType.PRIVATE_WITH_EGRESS,
         },
+        associatePublicIpAddress: usePublicSubnet ? true : undefined,
         securityGroup: props.securityGroup,
         blockDevices: [{
           deviceName: '/dev/xvda',
@@ -667,7 +671,7 @@ export class InfraStack extends Stack {
           minCapacity: managerAsgCapacity,
           desiredCapacity: managerAsgCapacity,
           vpcSubnets: {
-            subnetType: SubnetType.PRIVATE_WITH_EGRESS,
+            subnetType: usePublicSubnet ? SubnetType.PUBLIC : SubnetType.PRIVATE_WITH_EGRESS,
           },
           init: CloudFormationInit.fromElements(...this.getCfnInitElement(this, clusterLogGroup, 'manager', defaultInstanceType.toString())),
           initOptions: {
@@ -713,7 +717,7 @@ export class InfraStack extends Stack {
         minCapacity: 1,
         desiredCapacity: 1,
         vpcSubnets: {
-          subnetType: SubnetType.PRIVATE_WITH_EGRESS,
+          subnetType: usePublicSubnet ? SubnetType.PUBLIC : SubnetType.PRIVATE_WITH_EGRESS,
         },
         init: CloudFormationInit.fromElements(...this.getCfnInitElement(this, clusterLogGroup, seedConfig,
           (seedConfig === 'seed-manager') ? defaultInstanceType.toString() : this.dataInstanceType.toString())),
@@ -748,7 +752,7 @@ export class InfraStack extends Stack {
         minCapacity: dataAsgCapacity,
         desiredCapacity: dataAsgCapacity,
         vpcSubnets: {
-          subnetType: SubnetType.PRIVATE_WITH_EGRESS,
+          subnetType: usePublicSubnet ? SubnetType.PUBLIC : SubnetType.PRIVATE_WITH_EGRESS,
         },
         init: CloudFormationInit.fromElements(...this.getCfnInitElement(this, clusterLogGroup, 'data', this.dataInstanceType.toString())),
         initOptions: {
@@ -785,7 +789,7 @@ export class InfraStack extends Stack {
           minCapacity: this.clientNodeCount,
           desiredCapacity: this.clientNodeCount,
           vpcSubnets: {
-            subnetType: SubnetType.PRIVATE_WITH_EGRESS,
+            subnetType: usePublicSubnet ? SubnetType.PUBLIC : SubnetType.PRIVATE_WITH_EGRESS,
           },
           init: CloudFormationInit.fromElements(...this.getCfnInitElement(this, clusterLogGroup, 'client', defaultInstanceType.toString())),
           initOptions: {
@@ -823,7 +827,7 @@ export class InfraStack extends Stack {
           minCapacity: this.mlNodeCount,
           desiredCapacity: this.mlNodeCount,
           vpcSubnets: {
-            subnetType: SubnetType.PRIVATE_WITH_EGRESS,
+            subnetType: usePublicSubnet ? SubnetType.PUBLIC : SubnetType.PRIVATE_WITH_EGRESS,
           },
           init: CloudFormationInit.fromElements(...this.getCfnInitElement(this, clusterLogGroup, 'ml', this.mlInstanceType.toString())),
           initOptions: {

--- a/lib/networking/vpc-stack.ts
+++ b/lib/networking/vpc-stack.ts
@@ -53,24 +53,26 @@ export class NetworkStack extends Stack {
       serverAccess = NetworkStack.getServerAccess(restrictServerAccessTo, serverAccessType);
     }
 
+    const maxAzsCtx = `${scope.node.tryGetContext('maxAzs')}`;
+    const maxAzs = maxAzsCtx !== 'undefined' ? parseInt(maxAzsCtx, 10) : 3;
+    const natGatewaysCtx = `${scope.node.tryGetContext('natGateways')}`;
+    const natGateways = natGatewaysCtx !== 'undefined' ? parseInt(natGatewaysCtx, 10) : undefined;
+
+    const subnetConfiguration = natGateways === 0
+      ? [{ name: 'public-subnet', subnetType: SubnetType.PUBLIC, cidrMask: 24 }]
+      : [
+        { name: 'public-subnet', subnetType: SubnetType.PUBLIC, cidrMask: 24 },
+        { name: 'private-subnet', subnetType: SubnetType.PRIVATE_WITH_EGRESS, cidrMask: 24 },
+      ];
+
     // VPC specs
     if (vpcId === 'undefined') {
       console.log('No VPC-Id Provided, a new VPC will be created');
       this.vpc = new Vpc(this, 'opensearchClusterVpc', {
         ipAddresses: IpAddresses.cidr(cidrRange),
-        maxAzs: 3,
-        subnetConfiguration: [
-          {
-            name: 'public-subnet',
-            subnetType: SubnetType.PUBLIC,
-            cidrMask: 24,
-          },
-          {
-            name: 'private-subnet',
-            subnetType: SubnetType.PRIVATE_WITH_EGRESS,
-            cidrMask: 24,
-          },
-        ],
+        maxAzs,
+        natGateways,
+        subnetConfiguration,
       });
     } else {
       console.log('VPC provided, using existing');
@@ -97,6 +99,10 @@ export class NetworkStack extends Stack {
     this.osSecurityGroup.addIngressRule(serverAccess, Port.tcp(5601));
     this.osSecurityGroup.addIngressRule(serverAccess, Port.tcp(8443));
     this.osSecurityGroup.addIngressRule(this.osSecurityGroup, Port.allTraffic());
+
+    if (natGateways === 0 && vpcId === 'undefined') {
+      this.osSecurityGroup.addIngressRule(Peer.ipv4(cidrRange), Port.tcp(9200));
+    }
   }
 
   private static getServerAccess(restrictServerAccessTo: string, serverAccessType: string): IPeer {

--- a/lib/networking/vpc-stack.ts
+++ b/lib/networking/vpc-stack.ts
@@ -58,6 +58,13 @@ export class NetworkStack extends Stack {
     const natGatewaysCtx = `${scope.node.tryGetContext('natGateways')}`;
     const natGateways = natGatewaysCtx !== 'undefined' ? parseInt(natGatewaysCtx, 10) : undefined;
 
+    if (natGateways === 0 && serverAccessType === 'ipv4' && restrictServerAccessTo === 'all') {
+      throw new Error(
+        'Public subnet mode (natGateways=0) requires restrictServerAccessTo to be a specific CIDR, '
+        + 'or use prefixList/securityGroupId access type to avoid exposing the cluster to the internet',
+      );
+    }
+
     const subnetConfiguration = natGateways === 0
       ? [{ name: 'public-subnet', subnetType: SubnetType.PUBLIC, cidrMask: 24 }]
       : [

--- a/lib/networking/vpc-stack.ts
+++ b/lib/networking/vpc-stack.ts
@@ -99,10 +99,6 @@ export class NetworkStack extends Stack {
     this.osSecurityGroup.addIngressRule(serverAccess, Port.tcp(5601));
     this.osSecurityGroup.addIngressRule(serverAccess, Port.tcp(8443));
     this.osSecurityGroup.addIngressRule(this.osSecurityGroup, Port.allTraffic());
-
-    if (natGateways === 0 && vpcId === 'undefined') {
-      this.osSecurityGroup.addIngressRule(Peer.ipv4(cidrRange), Port.tcp(9200));
-    }
   }
 
   private static getServerAccess(restrictServerAccessTo: string, serverAccessType: string): IPeer {

--- a/test/opensearch-cluster-cdk.test.ts
+++ b/test/opensearch-cluster-cdk.test.ts
@@ -6,7 +6,7 @@ this file be licensed under the Apache-2.0 license or a
 compatible open source license. */
 
 import { App, Stack } from 'aws-cdk-lib';
-import { Template } from 'aws-cdk-lib/assertions';
+import { Match, Template } from 'aws-cdk-lib/assertions';
 import { InfraStack } from '../lib/infra/infra-stack';
 import { NetworkStack } from '../lib/networking/vpc-stack';
 import { arm64Ec2InstanceType, x64Ec2InstanceType } from '../lib/opensearch-config/node-config';
@@ -1804,6 +1804,111 @@ test('Throw error when gRPC port conflicts with Dashboards port', () => {
     // @ts-ignore
     expect(error.message).toEqual('gRPC cannot be mapped to the same port as OpenSearch or OpenSearch-Dashboards! Please provide different port numbers. Current mapping is OpenSearch:443 Dashboards:8443 gRPC:8443');
   }
+});
+
+test('Test VPC with natGateways=0 creates only public subnets', () => {
+  const app = new App({
+    context: {
+      natGateways: '0',
+      maxAzs: '2',
+      serverAccessType: 'ipv4',
+      restrictServerAccessTo: '10.10.10.10/32',
+    },
+  });
+
+  const netStack = new NetworkStack(app, 'opensearch-network-stack', {
+    env: { account: 'test-account', region: 'us-east-1' },
+  });
+
+  const template = Template.fromStack(netStack);
+  template.resourceCountIs('AWS::EC2::NatGateway', 0);
+  template.resourceCountIs('AWS::EC2::VPC', 1);
+  template.resourceCountIs('AWS::EC2::SecurityGroup', 1);
+});
+
+test('Test SG has no VPC CIDR ingress rule on 9200 in public mode', () => {
+  const app = new App({
+    context: {
+      natGateways: '0',
+      serverAccessType: 'ipv4',
+      restrictServerAccessTo: '10.10.10.10/32',
+    },
+  });
+
+  const netStack = new NetworkStack(app, 'opensearch-network-stack', {
+    env: { account: 'test-account', region: 'us-east-1' },
+  });
+
+  const template = Template.fromStack(netStack);
+  template.hasResourceProperties('AWS::EC2::SecurityGroup', {
+    SecurityGroupIngress: Match.not(
+      Match.arrayWith([
+        Match.objectLike({
+          CidrIp: '10.0.0.0/16',
+          FromPort: 9200,
+          ToPort: 9200,
+        }),
+      ]),
+    ),
+  });
+});
+
+test('Throw error when natGateways=0 and restrictServerAccessTo is all', () => {
+  const app = new App({
+    context: {
+      natGateways: '0',
+      serverAccessType: 'ipv4',
+      restrictServerAccessTo: 'all',
+    },
+  });
+
+  try {
+    const netStack = new NetworkStack(app, 'opensearch-network-stack', {
+      env: { account: 'test-account', region: 'us-east-1' },
+    });
+
+    // eslint-disable-next-line no-undef
+    fail('Expected an error to be thrown');
+  } catch (error) {
+    expect(error).toBeInstanceOf(Error);
+    // @ts-ignore
+    expect(error.message).toContain('Public subnet mode (natGateways=0) requires restrictServerAccessTo');
+  }
+});
+
+test('Test single-node cluster in public subnet mode with natGateways=0', () => {
+  const app = new App({
+    context: {
+      securityDisabled: true,
+      minDistribution: false,
+      distributionUrl: 'www.example.com',
+      cpuArch: 'x64',
+      singleNodeCluster: true,
+      distVersion: '2.0.0',
+      serverAccessType: 'prefixList',
+      restrictServerAccessTo: 'pl-12345',
+      natGateways: '0',
+    },
+  });
+
+  const netStack = new NetworkStack(app, 'opensearch-network-stack', {
+    env: { account: 'test-account', region: 'us-east-1' },
+  });
+
+  // @ts-ignore
+  const infraStack = new InfraStack(app, 'opensearch-infra-stack', {
+    vpc: netStack.vpc,
+    securityGroup: netStack.osSecurityGroup,
+    env: { account: 'test-account', region: 'us-east-1' },
+  });
+
+  const infraTemplate = Template.fromStack(infraStack);
+  infraTemplate.resourceCountIs('AWS::EC2::Instance', 1);
+  infraTemplate.hasResourceProperties('AWS::EC2::Instance', {
+    NetworkInterfaces: Match.arrayWith([
+      Match.objectLike({ AssociatePublicIpAddress: true }),
+    ]),
+  });
 });
 
 test('Test gRPC with custom port mapping', () => {


### PR DESCRIPTION
## Summary

Two new opt-in context variables for VPC configuration:

| Variable | Default | Effect |
|----------|---------|--------|
| `maxAzs` | 3 | Number of availability zones |
| `natGateways` | 1 per AZ | Number of NAT gateways |

When `natGateways=0`, private subnets are omitted and instances are placed in public subnets directly. Zero NAT gateways, zero EIPs. Useful for short-lived benchmark clusters where the security group (prefix list / IP restriction) is the access boundary.

No change to existing behavior — omitting these vars produces byte-identical CloudFormation templates.

### Example

```bash
cdk deploy '*' -c maxAzs=1 -c natGateways=0 \
  -c singleNodeCluster=true -c serverAccessType=prefixList ...
```

Tip: reuse the network stack across clusters by passing a shared `networkStackSuffix`:

```bash
cdk deploy '*' -c suffix=cluster-a -c networkStackSuffix=shared -c natGateways=0 ...
cdk deploy '*' -c suffix=cluster-b -c networkStackSuffix=shared ...
```

## Test plan

- [x] `npm run build` — 50/50 tests pass
- [x] `cdk synth` without new vars — byte-identical to main
- [x] `cdk synth` with `maxAzs=1 natGateways=0` — 1 subnet, 0 NAT, 0 EIP
- [x] Multi-node + `natGateways=0` synths without error
- [x] End-to-end deploy in us-west-2 — cluster green, NLB healthy