### PR TITLE
 Add env to release workflow and fix syntax 

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,4 +1,4 @@
-name: Draft a release
+name: Release Workflow
 
 on:
   push:
@@ -6,49 +6,31 @@ on:
       - "*"
 
 jobs:
-  draft-a-release:
+  release-to-npm:
+    environment: release-approval
     runs-on: ubuntu-latest
     permissions:
-      id-token: write  # Required for OIDC
+      id-token: write
       contents: write
-      issues: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      - id: get_data
-        run: |
-          echo "approvers=$(cat .github/CODEOWNERS | grep @ | tr -d '* ' | sed 's/@/,/g' | sed 's/,//1')" >> $GITHUB_OUTPUT
-          echo "version=$(cat package.json | jq .version | tr -d "\"")" >> $GITHUB_OUTPUT
-      - uses: trstringer/manual-approval@v1
-        with:
-          secret: ${{ github.TOKEN }}
-          approvers: ${{ steps.get_data.outputs.approvers }}
-          minimum-approvals: 2
-          issue-title: 'Release opensearch-cluster-cdk : ${{ steps.get_data.outputs.version }}'
-          issue-body: "Please approve or deny the release of opensearch-cluster-cdk. **VERSION**: ${{ steps.get_data.outputs.version }} **TAG**: ${{ github.ref_name }}  **COMMIT**: ${{ github.sha }}"
-          exclude-workflow-initiator-as-approver: true
-      - name: Set up node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.16.0
-          registry-url: 'https://registry.npmjs.org'
-      - name: Build and package
-        run: |
-          npm install && npm run build
-          npm pack
-          filename=`ls | grep opensearch-project-opensearch-cluster-cdk`
-          mkdir publish-cluster-cdk && mv $filename publish-cluster-cdk/opensearch-cluster-cdk.tar.gz
-          tar -cvf artifacts.tar.gz publish-cluster-cdk
-      - uses: actions/setup-node@v4
+        uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
       - run: npm ci
+
+      - name: Build
+        run: npm install && npm run build
+
       - run: npm publish
-      - name: Draft a release
-        uses: softprops/action-gh-release@v1
+
+      - name: Create a release
+        uses: softprops/action-gh-release@v2
         with:
           draft: false
           generate_release_notes: true
-          files: |
-            artifacts.tar.gz

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@opensearch-project/opensearch-cluster-cdk",
   "version": "1.4.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/opensearch-project/opensearch-cluster-cdk"
+  },
   "bin": {
     "cdk_v2": "bin/app.js"
   },


### PR DESCRIPTION
### Description
This PR adds a bunch of guardrails to the release workflow. Below are the changes:
- Added release environment to the release workflow (release-env) to leverage GitHub environment protection rules for approval instead of the manual-approval GitHub Action.
- Enabled provenance by adding the repository.url field to package.json, which is required for npm's sigstore provenance attestation when publishing via trusted publishers.
- Removed artifact bundling — the old workflow packed a .tar.gz artifact and attached it to the GitHub release. This is unnecessary since users can download the package directly from npmjs.org.
- Simplified the release workflow that uses updated actions (checkout@v6, setup-node@v6) and removes the manual approval issue step (now handled by the environment).

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
