### PR TITLE
Add security group to NLB for cluster SG reuse

### DIFF
--- a/lib/infra/infra-stack.ts
+++ b/lib/infra/infra-stack.ts
@@ -472,6 +472,7 @@ export class InfraStack extends Stack {
         vpc: props.vpc,
         internetFacing: (!this.isInternal),
         crossZoneEnabled: true,
+        securityGroups: [props.securityGroup],
       });
       break;
     case LoadBalancerType.ALB:

--- a/test/opensearch-cluster-cdk.test.ts
+++ b/test/opensearch-cluster-cdk.test.ts
@@ -1845,3 +1845,42 @@ test('Test gRPC with custom port mapping', () => {
     Protocol: 'TCP',
   });
 });
+
+test('Test NLB uses the same security group as the cluster', () => {
+  const app = new App({
+    context: {
+      securityDisabled: true,
+      minDistribution: false,
+      distributionUrl: 'www.example.com',
+      cpuArch: 'x64',
+      singleNodeCluster: false,
+      dashboardsUrl: 'www.example.com',
+      distVersion: '1.0.0',
+      serverAccessType: 'ipv4',
+      restrictServerAccessTo: 'all',
+      loadBalancerType: 'nlb',
+    },
+  });
+
+  // WHEN
+  const networkStack = new NetworkStack(app, 'opensearch-network-stack', {
+    env: { account: 'test-account', region: 'us-east-1' },
+  });
+
+  const infraStack = new InfraStack(app as unknown as Stack, 'opensearch-infra-stack', {
+    vpc: networkStack.vpc,
+    securityGroup: networkStack.osSecurityGroup,
+    env: { account: 'test-account', region: 'us-east-1' },
+  });
+
+  // THEN
+  const infraTemplate = Template.fromStack(infraStack);
+  const template = infraTemplate.toJSON();
+  const nlbResource = Object.values(template.Resources).find(
+    (r: any) => r.Type === 'AWS::ElasticLoadBalancingV2::LoadBalancer' && r.Properties.Type === 'network',
+  ) as any;
+
+  expect(nlbResource).toBeDefined();
+  expect(nlbResource.Properties.SecurityGroups).toBeDefined();
+  expect(nlbResource.Properties.SecurityGroups.length).toBe(1);
+});


### PR DESCRIPTION
## Summary
- Attach the cluster security group to the Network Load Balancer via `securityGroups: [props.securityGroup]`, so the NLB shares the same SG as the OpenSearch nodes
- Eliminates the need for additional inbound rules when using an NLB, matching the existing ALB behavior
- Adds a test verifying the NLB CloudFormation resource includes the security group

## Test plan
- [x] All 51 existing tests pass
- [x] New test verifies NLB resource has `SecurityGroups` property with exactly one entry
- [ ] Deploy a test stack with `loadBalancerType=nlb` and confirm the NLB is reachable on the cluster ports without extra SG rules