### PR TITLE
add no-op remote_cluster_client role to all nodes

### DIFF
--- a/lib/opensearch-config/node-config.ts
+++ b/lib/opensearch-config/node-config.ts
@@ -11,21 +11,21 @@ import { EbsDeviceVolumeType } from 'aws-cdk-lib/aws-autoscaling';
 export const nodeConfig = new Map<string, object>();
 
 nodeConfig.set('manager', {
-  'node.roles': ['cluster_manager'],
+  'node.roles': ['cluster_manager', 'remote_cluster_client'],
 });
 
 nodeConfig.set('data', {
-  'node.roles': ['data', 'ingest'],
+  'node.roles': ['data', 'ingest', 'remote_cluster_client'],
 });
 
 nodeConfig.set('seed-manager', {
   'node.name': 'seed',
-  'node.roles': ['cluster_manager'],
+  'node.roles': ['cluster_manager', 'remote_cluster_client'],
 });
 
 nodeConfig.set('seed-data', {
   'node.name': 'seed',
-  'node.roles': ['cluster_manager', 'data'],
+  'node.roles': ['cluster_manager', 'data', 'remote_cluster_client'],
 });
 
 nodeConfig.set('client', {


### PR DESCRIPTION
### Description
Add `remote_cluster_client` node role to all nodes, this is a no-op role if CCR is not setup on the cluster and silently ignored. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
